### PR TITLE
ClimaLand: all CO2 fluxes in mol CO2 m-2 s-1

### DIFF
--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -120,6 +120,11 @@ description = "Constant describing cost of maintaining electron transport (unitl
 
 # SoilCO2Model
 
+[kg_C_to_mol_CO2_factor]
+value = 83.26 
+type = "float"
+description = "Conversion factor from kg C to mol CO2"
+
 [CO2_diffusion_coefficient]
 value = 1.39e-5
 type = "float"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -27,11 +27,6 @@ value = 0.1
 type = "float"
 description = "Ratio stem nitrogen to top leaf nitrogen (unitless)"
 
-[mol_CO2_to_kg_C_factor]
-value = 0.012
-type = "float"
-description = "Factor to convert from mol CO2 to kg C"
-
 [relative_contribution_factor]
 value = 0.25
 type = "float"


### PR DESCRIPTION
This PR goes along with [ClimaLand PR #731](https://github.com/CliMA/ClimaLand.jl/pull/731),
we are refactoring ClimaLand to express all CO2 fluxes in mol CO2 m-2 s-1, previously there was some in
g C m-2 s-1 and some in mol CO2 m-2 s-1
