### PR TITLE
Remove dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 ClimaParams.jl Release Notes
 ========================
 
+v0.10.14
+------
+- Remove all dependencies ([#208](https://github.com/CliMA/ClimaParams.jl/pull/208))
+
 v0.10.13
 ------
 - Remove mol co2 to kg C factor AutotrophicResp, add kg C to mol CO2 factor Heterotrophic Resp ([#205](https://github.com/CliMA/ClimaParams.jl/pull/205))

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,15 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.13"
+version = "0.10.14"
 
 [deps]
-DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DocStringExtensions = "0.8, 0.9"
 julia = "1"
 TOML = "1"
 Test = "1"

--- a/src/ClimaParams.jl
+++ b/src/ClimaParams.jl
@@ -1,7 +1,6 @@
 module ClimaParams
 
 using TOML
-using DocStringExtensions
 
 export AbstractTOMLDict
 export ParamDict

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -19,7 +19,8 @@ Uses the name to search
 
 # Fields
 
-$(DocStringExtensions.FIELDS)
+- `data`: dictionary representing a default/merged parameter TOML file
+- `override_dict`: either a nothing, or a dictionary representing an override parameter TOML file
 """
 struct ParamDict{FT} <: AbstractTOMLDict{FT}
     "dictionary representing a default/merged parameter TOML file"


### PR DESCRIPTION
ClimaParams should not depend on `Test` (no package should do so). `DocStringExtensions` was barely used, so I removed it (every package that uses ClimaParams inherits this dependency)

Closes #207 