### PR TITLE
Adding documentation; cleanup of docstrings and TOML descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,101 @@
+<div align="center">
+  <img src="docs/src/assets/logo.svg" alt="ClimaParams.jl Logo" width="128" height="128">
+</div>
+
 # ClimaParams.jl
 
-Contains all universal constants and physical parameters in the [CliMA ecosystem](https://github.com/CliMA).
+A centralized parameter management system for climate modeling. ClimaParams.jl supports physical constants, planetary properties, and tunable parameters designed for calibration with data assimilation and machine learning tools. 
 
-|||
-|---------------------:|:----------------------------------------------|
-| **Docs Build**       | [![docs build][docs-bld-img]][docs-bld-url]   |
-| **Documentation**    | [![dev][docs-dev-img]][docs-dev-url]          |
-| **GHA CI**           | [![gha ci][gha-ci-img]][gha-ci-url]           |
-| **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
+|                           |                                                                          |
+|--------------------------:|:-------------------------------------------------------------------------|
+| **Stable Release**        | [![stable][stable-img]][stable-url] [![docs-stable][docs-stable-img]][docs-stable-url] |
+| **Latest Documentation**  | [![dev][docs-latest-img]][docs-latest-url]                                |
+| **Unit Tests**            | [![unit tests][unit-tests-img]][unit-tests-url] [![codecov][codecov-img]][codecov-url] |
+| **Downloads**             | [![Downloads][dlt-img]][dlt-url]                                          |
 
-[docs-bld-img]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/Docs.yml/badge.svg
-[docs-bld-url]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/Docs.yml
+[docs-latest-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-latest-url]: https://CliMA.github.io/ClimaParams.jl/dev/
 
-[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
-[docs-dev-url]: https://CliMA.github.io/ClimaParams.jl/dev/
+[stable-img]: https://img.shields.io/github/v/release/CliMA/ClimaParams.jl?label=stable
+[stable-url]: https://github.com/CliMA/ClimaParams.jl/releases/latest
 
-[gha-ci-img]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/ci.yml/badge.svg
-[gha-ci-url]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/ci.yml
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-green.svg
+[docs-stable-url]: https://CliMA.github.io/ClimaParams.jl/stable/
+
+[unit-tests-img]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/ci.yml/badge.svg
+[unit-tests-url]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/ci.yml
 
 [codecov-img]: https://codecov.io/gh/CliMA/ClimaParams.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/CliMA/ClimaParams.jl
 
+[dlt-img]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Ftotal_downloads%2FClimaParams&query=total_requests&label=Downloads
+[dlt-url]: https://juliapkgstats.com/pkg/ClimaParams
+
+## Overview
+
+ClimaParams.jl provides a single source of truth for the parameters used in the [Climate Modeling Alliance (CliMA)](https://github.com/CliMA) ecosystem. By centralizing parameters across all model components (atmosphere, ocean, land, etc.), it enables joint calibration of interconnected climate processes through data assimilation and machine learning pipelines. This unified approach ensures that parameters shared between components remain consistent and can be optimized together, leading to more physically coherent model calibration.
+
+The package manages two fundamental types of values:
+- Physical and planetary *constants* (e.g., speed of light or planet radius)
+- Tunable model *parameters* that can be calibrated individually or jointly across components
+
+## Features
+
+- **Centralized Management**: A single, authoritative source for all model constants and parameters, enabling joint calibration of interconnected processes.
+- **Type-Safe Retrieval**: Guaranteed type-safety with automatic validation and conversion for floating-point, integer, string, and boolean types.
+- **Override System**: Support for parameter overrides with precedence handling for flexible experimentation.
+- **Parameter Tagging**: Logically group values by model component (e.g., atmosphere, land) for easy filtering and retrieval.
+- **Machine Learning Integration**: Seamless integration with data assimilation and ML calibration workflows, including joint parameter optimization across components.
+- **TOML Configuration**: Human-readable TOML files define parameters and their metadata.
+- **Reproducibility**: Automatic logging of parameter sets used in model runs to ensure scientific reproducibility.
+- **Multi-Planet Support**: An extensible framework for simulations of Earth and other planetary bodies.
+
+## Quick Example
+
+```julia
+using ClimaParams
+
+# Floating-point type for parameters
+FT = Float64
+
+# Create a dictionary containing all default parameters, cast to the chosen float type
+param_dict = create_toml_dict(FT)
+
+# Retrieve a struct of physical constants by name
+constants = get_parameter_values(
+    param_dict, 
+    ["gravitational_acceleration", "planet_radius", "light_speed"],
+)
+# Access constants, e.g.: 
+constants.gravitational_acceleration
+
+# Retrieve parameters and assign them custom names for convenience
+params = get_parameter_values(
+    param_dict,
+    Dict("universal_gas_constant" => "R", "gravitational_acceleration" => "g"),
+)
+# Access parameters, e.g. 
+params.R
+
+# Get all parameters associated with a specific tag
+atmospheric_params = get_tagged_parameter_values(param_dict, "atmosphere")
+```
+
+## Parameter Categories
+
+ClimaParams manages two main categories of parameters:
+
+- **Constants**: Immutable physical values. This includes universal constants (e.g., speed of light) and planet-specific properties (e.g., gravitational acceleration or planetary radius)
+- **Model Parameters**: Tunable values that are subject to calibration via data assimilation or machine learning. These often correspond to specific physical processes, including:
+  - Atmospheric physics 
+  - Land surface 
+  - Turbulence closures
+  - Biogeochemistry
+
+## Integration with CliMA Models
+
+By providing a centralized source of parameters, ClimaParams.jl is essential for the interoperability and reliability of the CliMA ecosystem. It is designed to:
+- Enable joint calibration of parameters across model components through unified data assimilation and machine learning pipelines
+- Ensure consistent parameter usage across all models (atmosphere, ocean, land, etc.)
+- Facilitate parameter sensitivity analysis and uncertainty quantification studies, jointly across model components
+- Enable reproducible experiments by explicitly logging the exact parameter sets used for each simulation

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1,28 +1,57 @@
-# API
-
 ```@meta
 CurrentModule = ClimaParams
 ```
 
-## Parameter dictionaries
+# API
+
+This page documents the functions and types available in ClimaParams.jl. The API is organized to follow a typical user workflow.
+
+## 1. Core Data Structures
+
+These are the main types for holding and interacting with parameters.
 
 ```@docs
 AbstractTOMLDict
 ParamDict
+Base.getindex
+float_type
 ```
 
-## File parsing and parameter logging
+## 2. Creating a Parameter Dictionary
 
-### User facing functions:
+The primary entry point is [`create_toml_dict`](@ref), which can be customized by merging multiple files.
+
 ```@docs
 create_toml_dict
+merge_toml_files
+```
+
+## 3. Accessing Parameter Values
+
+Once a [`ParamDict`](@ref) is created, you can retrieve parameter values in several ways. The most common method is [`get_parameter_values`](@ref).
+
+```@docs
 get_parameter_values
+```
+
+### Tag-Based Retrieval
+
+Parameters can be organized in the TOML file with `tag` entries. These functions allow you to retrieve all parameters associated with one or more tags.
+
+```@docs
 get_tagged_parameter_values
 get_tagged_parameter_names
 fuzzy_match
-float_type
+```
+
+## 4. Utilities for Integration and Reproducibility
+
+These functions support logging, validation, and integration with user-defined parameter structs.
+
+```@docs
 log_parameter_information
 write_log_file
-merge_toml_files
+check_override_parameter_usage
+log_component!
 create_parameter_struct
 ```

--- a/docs/src/assets/logo.svg
+++ b/docs/src/assets/logo.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+	
+	<!-- Four horizontal lines in Julia colors -->
+	<!-- Purple line -->
+	<rect x="35" y="50" width="57" height="8" fill="#9558B2" rx="4"/>
+	<rect x="108" y="50" width="57" height="8" fill="#9558B2" rx="4"/>
+	<circle cx="100" cy="54" r="8" fill="none" stroke="#9558B2" stroke-width="4"/>
+	
+	<!-- Green line -->
+	<rect x="35" y="80" width="37" height="8" fill="#389826" rx="4"/>
+	<rect x="88" y="80" width="77" height="8" fill="#389826" rx="4"/>
+	<circle cx="80" cy="84" r="8" fill="none" stroke="#389826" stroke-width="4"/>
+	
+	<!-- Red line -->
+	<rect x="35" y="110" width="87" height="8" fill="#CB3C33" rx="4"/>
+	<rect x="138" y="110" width="27" height="8" fill="#CB3C33" rx="4"/>
+	<circle cx="130" cy="114" r="8" fill="none" stroke="#CB3C33" stroke-width="4"/>
+	
+	<!-- Blue line -->
+	<rect x="35" y="140" width="57" height="8" fill="#4063D8" rx="4"/>
+	<rect x="108" y="140" width="57" height="8" fill="#4063D8" rx="4"/>
+	<circle cx="100" cy="144" r="8" fill="none" stroke="#4063D8" stroke-width="4"/>
+	
+</svg>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,24 +1,81 @@
 # ClimaParams.jl
 
-This package contains all of the parameters used across the [CliMA](https://github.com/CliMA) organization. Some parameters are simply global constants (e.g., speed of light), while others are parameters that may be tuned in a machine-learning layer that sits on-top of the climate model.
+A centralized parameter management system for climate modeling, ClimaParams.jl supports physical constants, planetary properties, and tunable parameters designed for calibration with data assimilation and machine learning tools.
+
+## Overview
+
+ClimaParams.jl provides a single source of truth for the parameters used in the [Climate Modeling Alliance (CliMA)](https://github.com/CliMA) ecosystem. By centralizing parameters across all model components (atmosphere, ocean, land, etc.), it enables joint calibration of interconnected climate processes through data assimilation and machine learning pipelines. This unified approach ensures that parameters shared between components remain consistent and can be optimized together, leading to more physically coherent model calibration.
+
+The package manages two fundamental types of values:
+- Physical and planetary *constants* (e.g., speed of light or planet radius)
+- Tunable model *parameters* that can be calibrated individually or jointly across components
 
 ## What parameters are good candidates for ClimaParams?
 
-ClimaParams serve several functionalities and require certain attributes. A parameter is a good candidate for ClimaParams if it has _all_ of the following attributes:
+A parameter is a good candidate for ClimaParams if it has _all_ of the following attributes:
 
  - The parameter does not vary in space
  - The parameter does not vary in time (per climate simulation)
- - The parameter is a function of only constants other ClimaParams and or constants
+ - The parameter is a function of only constants and other ClimaParams
 
 ## Getting Started
 
 The basic flow is as follows:
 1. Create the parameter dictionary with your desired floating point type
 2. Retrieve parameters
-```julia
+
+```@example howto
 import ClimaParams as CP
+
+# Create parameter dictionary with default values
 param_dict = CP.create_toml_dict(Float64)
-params = CP.get_parameter_values(param_dict, ["gravitational_acceleration", "planet_radius"])
+
+# Retrieve physical constants
+constants = CP.get_parameter_values(
+    param_dict, 
+    ["gravitational_acceleration", "planet_radius", "light_speed"]
+)
+
+# Retrieve parameters with custom names
+params = CP.get_parameter_values(
+    param_dict,
+    Dict("universal_gas_constant" => "R", "gravitational_acceleration" => "g")
+)
+```
+Or retrieve all parameters associated with a specific tag, for example, "SurfaceFluxes"
+
+```@example howto
+sf_params = CP.get_tagged_parameter_values(param_dict, "surfacefluxes") 
 ```
 
-See the [The TOML parameter file interface](@ref) and [Basic Parameter Retrieval](@ref) for detailed usage examples and integration into your code.
+## Best Practices
+
+1. **Use descriptive parameter names** in your TOML files
+2. **Log component usage** by specifying component names
+3. **Use name maps** for shorter, more intuitive variable names
+4. **Tag related parameters** for easy filtering
+5. **Create parameter structs** to encapsulate related parameters and their relationships
+6. **Validate parameter values** before using them in simulations
+
+## Documentation Overview
+
+### Core Usage
+
+- **[Parameter retrieval](param_retrieval.md)**: Learn how to retrieve parameters from dictionaries, use name maps, and work with tagged parameters. Includes practical examples from the CliMA ecosystem.
+
+### Configuration and File Format
+
+- **[TOML file interface](toml.md)**: Understand how to define parameters in TOML files, including value types, descriptions, tags, and advanced features for calibration workflows.
+
+### API Reference
+
+- **[API](API.md)**: Complete reference documentation for all functions and types in ClimaParams.jl, organized by functionality and typical usage patterns.
+
+### Advanced Topics
+
+- **[Parameter Structs](param_retrieval.md#parameter-structs)**: Learn how to create custom parameter structs for your models.
+- **[Component Logging](param_retrieval.md#component-logging)**: Understand how to track parameter usage across model components for logging and validation.
+- **[Override Files](toml.md#override-files)**: See how to customize parameters for specific experiments.
+- **[Tagged Parameters](param_retrieval.md#tagged-parameters)**: Discover how to organize and retrieve related parameters.
+
+For detailed usage examples and integration into your code, start with the Parameter retrieval guide, then explore the TOML file interface for configuration details.

--- a/docs/src/param_retrieval.md
+++ b/docs/src/param_retrieval.md
@@ -1,32 +1,60 @@
-## Basic Parameter Retrieval
+# Basic Parameter Retrieval
 
-There are two keys functions for parameter retrieval:
-- `create_toml_dict` constructs a TOML dictionary which stores parameters,
-- `get_parameter_values` retrieves parameters from the TOML dictionary.
+ClimaParams.jl provides a centralized system for managing climate model parameters. The core workflow involves creating a parameter dictionary and then retrieving specific parameters from it.
 
-To construct a TOML dictionary, pass in the desired floating point type. 
+## Core Functions
+
+There are three key functions for parameter retrieval:
+- [`create_toml_dict`](@ref) constructs a parameter dictionary from TOML files
+- [`get_parameter_values`](@ref) retrieves parameters from the dictionary
+
+## Creating Parameter Dictionaries
+
+To construct a parameter dictionary, pass in the desired floating point type. 
 This will source parameter values from the global default list stored in `src/parameters.toml`
-```julia
+
+```@example howto
 import ClimaParams as CP
 toml_dict = CP.create_toml_dict(Float64)
+nothing # hide
 ```
-To retrieve parameters, pass in the TOML dictionary and the names that match the default parameters.
+
+You can also specify custom override and default files:
+
 ```julia
-params = CP.get_parameter_values(toml_dict, ["gravitational_acceleration", "gas_constant"])
-params.gravitational_acceleration
-params.gas_constant
+# With custom files
+toml_dict = CP.create_toml_dict(
+    Float64,
+    override_file = "my_parameters.toml",
+    default_file = "default_parameters.toml"
+)
 ```
-You can also pass in a single parameter name:
-```julia
-params = CP.get_parameter_values(toml_dict, "gravitational_acceleration")
+
+## Retrieving Parameters
+
+To retrieve parameters, pass in the TOML dictionary and the parameter names that match those in the TOML file.
+
+```@example howto
+params = CP.get_parameter_values(toml_dict, ["universal_gas_constant", "gravitational_acceleration"])
+params.universal_gas_constant
 params.gravitational_acceleration
+nothing #hide
+```
+
+You can also use direct indexing to obtain values from the parameter dictionary:
+```@example howto
+toml_dict["gravitational_acceleration"]
 ```
 
 ## Name Maps
-Name maps are a way to map global descriptive parameter names (indexing the toml_dict) 
-to local user-defined names. One can define a name with a NamedTuple as follows...
-It will return a NamedTuple of the parameters with your given variable names.
-```julia
+
+Name maps allow you to map global parameter names to local variable names for
+convenience. This is especially useful when you want shorter, more intuitive
+variable names in your code.
+
+### Using NamedTuples
+
+```@example howto
 name_map = (;
     :gravitational_acceleration => :g,
     :angular_velocity_planet_rotation => :omega
@@ -35,46 +63,90 @@ params = CP.get_parameter_values(toml_dict, name_map)
 params.g  # gives value field of gravitational_acceleration
 params.omega
 ```
-A name map does not strictly need to be a NamedTuple. It can be a Dict, Vector, Tuple, or Varargs of Pairs.
-The entries in the name map can also be Strings instead of Symbols.
 
-```julia
+### Using Dictionaries
+
+```@example howto
 name_map = Dict("gravitational_acceleration" => "g", "angular_velocity_planet_rotation" => "omega")
 params = CP.get_parameter_values(toml_dict, name_map)
+nothing # hide
+```
 
-params = CP.get_parameter_values(toml_dict, :gravitational_acceleration => :g,
-                                            :angular_velocity_planet_rotation => :omega)
+### Using Varargs
+
+```@example howto
+params = CP.get_parameter_values(toml_dict, 
+    :gravitational_acceleration => :g,
+    :angular_velocity_planet_rotation => :omega
+)
+nothing # hide
+```
+
+## Component Logging
+
+You can specify a component name when retrieving parameters. This logs which parameters are used by which model component, which is useful for reproducibility:
+
+```@example howto
+params = CP.get_parameter_values(toml_dict, ["gravitational_acceleration"], "Ocean")
+nothing # hide
+```
+
+## Tagged Parameters
+
+ClimaParams supports parameter tagging for easy filtering. You can retrieve all parameters with a specific tag:
+
+```@example howto
+# Get all atmospheric parameters
+atmospheric_params = CP.get_tagged_parameter_values(toml_dict, "atmosphere")
+
+# Get parameters with multiple tags
+physics_params = CP.get_tagged_parameter_values(toml_dict, ["atmosphere", "turbulence"])
+nothing # hide
 ```
 
 ## Example Usage
 
-### An example from `Thermodynamics.jl`
+### Simple Parameter Retrieval
 
-#### In the user-facing driver file
+Here's a basic example showing how to retrieve parameters for use in a simulation:
+
 ```julia
-import ClimaParams
-using Thermodynamics
+import ClimaParams as CP
 
-thermo_params = ThermodynamicsParameters(Float64)
+# Create parameter dictionary
+toml_dict = CP.create_toml_dict(Float64)
+
+# Retrieve specific parameters
+params = CP.get_parameter_values(toml_dict, [
+    "gravitational_acceleration",
+    "universal_gas_constant", 
+    "planet_radius"
+])
+
+# Use parameters in your code
+g = params.gravitational_acceleration
+R = params.universal_gas_constant
+
+# Alternatively, you can index directly into the parameter dict
+toml_dict["gravitational_acceleration"]
+
 ```
 
-#### In the source code for `Thermodynamics.jl`
+## Parameter Structs
+
+For more complex applications, you can build parameter structs that encapsulate
+related parameters. Here's a complete example from the CliMA ecosystem:
+
+### Building Parameter Structs
 
 ```julia
 Base.@kwdef struct ThermodynamicsParameters{FT}
-    gas_constant::FT
+    universal_gas_constant::FT
     molmass_dryair::FT
-    ...
     # derived parameters
-    R_d::FT = gas_constant / molmass_dryair
+    R_d::FT = universal_gas_constant / molmass_dryair
 end
-```
-- The struct is parameterized by `{FT}` which is a user-determined float precision.
-- Only relevant parameters used in `Thermodynamics` are stored here.
-- A keyword based constructor is provided so we do not rely on parameter order.
 
-The constructor is as follows
-```julia
 # Float-type constructor
 ThermodynamicsParameters(::Type{FT}) = ThermodynamicsParameters(CP.create_toml_dict(FT))
 
@@ -87,79 +159,132 @@ function ThermodynamicsParameters(toml_dict)
         :thermodynamics_temperature_reference => :T_0,
         :temperature_water_freeze => :T_freeze,
         :isobaric_specific_heat_ice => :cp_i,
-        ...
     ]
 
-    parameters = ClimaParams.get_parameter_values(
+    parameters = CP.get_parameter_values(
         toml_dict,
         name_map,
-        "Thermodynamics",
+        "Thermodynamics",  # Component name for logging
     )
 
     FT = CP.float_type(toml_dict)
     return ThermodynamicsParameters{FT}(parameters...)
 end
+nothing # hide
 ```
 
-- The constructor takes in a `toml_dict` produced from reading the TOML file.
-- The name map maps from the globally-defined parameter names to the user-defined names. 
-- We obtain the NamedTuple parameters from `get_parameter_values(toml_dict, name_map, component_name)` The `component_name` is a string used for the parameter log.
-- We return the `ThermodynamicsParameters{FT}`, where FT is an enforced float type (e.g. single or double precision).
+### Hierarchical Parameter Sets
 
+For complex models with multiple components, you can build hierarchical
+parameter sets that maintain parameter relationships:
 
-### An example with modular components from `CloudMicrophysics.jl`
-
-#### In the user-facing driver file
-
-Here we build a `CloudMicrophysics` parameter set. In this case, the user wishes to use a
-0-moment microphysics parameterization scheme.
 ```julia
-import ClimaParams
-import Thermodynamics
-import CloudMicrophysics
-
-#load defaults
-toml_dict = ClimaParams.create_toml_dict(Float64)
-
-#build the low level parameter set
-param_therm = Thermodynamics.Parameters.ThermodynamicsParameters(toml_dict)
+# Build individual component parameter sets
+param_therm = ThermodynamicsParameters(toml_dict)
 param_0M = CloudMicrophysics.Microphysics_0M_Parameters(toml_dict)
 
-#build the hierarchical parameter set
+# Combine into a hierarchical parameter set
 parameter_set = CloudMicrophysics.CloudMicrophysicsParameters(
     toml_dict,
     param_0M,
     param_therm
 )
 ```
-!!! note
-    The exact APIs here are subject to change.
 
-#### In the source code for `CloudMicrophysics.jl`
+## Advanced Examples from CliMA
 
-Build the different options for a Microphysics parameterizations
+### Thermodynamics.jl Example
+
+Here's how [`Thermodynamics.jl`](https://github.com/CliMA/Thermodynamics.jl)
+uses ClimaParams in practice:
+
+#### User-facing driver file
+```julia
+import ClimaParams as CP
+using Thermodynamics
+
+thermo_params = ThermodynamicsParameters(Float64)
+```
+
+#### Source code implementation
+```julia
+Base.@kwdef struct ThermodynamicsParameters{FT}
+    LH_v0::FT
+    LH_s0::FT
+    # ... other parameters
+    # derived parameters
+    LH_f0 = LH_s0 - LH_v0
+end
+
+# Float-type constructor
+ThermodynamicsParameters(::Type{FT}) = ThermodynamicsParameters(CP.create_toml_dict(FT))
+
+# TOML dictionary constructor
+function ThermodynamicsParameters(toml_dict)
+    name_map = [
+        :temperature_triple_point => :T_triple,
+        :adiabatic_exponent_dry_air => :kappa_d,
+        :pressure_triple_point => :press_triple,
+        :thermodynamics_temperature_reference => :T_0,
+        :temperature_water_freeze => :T_freeze,
+        :isobaric_specific_heat_ice => :cp_i,
+        # ... more mappings
+    ]
+
+    parameters = CP.get_parameter_values(
+        toml_dict,
+        name_map,
+        "Thermodynamics",
+    )
+    
+    # Create the parameter struct, preserving parameter relationships
+    FT = CP.float_type(toml_dict)
+    return ThermodynamicsParameters{FT}(parameters...)
+end
+```
+
+### CloudMicrophysics.jl Example
+
+Here's how [`CloudMicrophysics.jl`](https://github.com/CliMA/CloudMicrophysics.jl) builds hierarchical parameter sets:
+
+#### User-facing driver file
+```julia
+import ClimaParams as CP
+import Thermodynamics
+import CloudMicrophysics
+
+# Load defaults
+toml_dict = CP.create_toml_dict(Float64)
+
+# Build the low level parameter sets
+param_therm = Thermodynamics.Parameters.ThermodynamicsParameters(toml_dict)
+param_0M = CloudMicrophysics.Microphysics_0M_Parameters(toml_dict)
+
+# Build the hierarchical parameter set
+parameter_set = CloudMicrophysics.CloudMicrophysicsParameters(
+    toml_dict,
+    param_0M,
+    param_therm
+)
+```
+
+#### Source code implementation
 ```julia
 abstract type AbstractMicrophysicsParameters end
 struct NoMicrophysicsParameters <: AbstractMicrophysicsParameters end
+
 Base.@kwdef struct Microphysics_0M_Parameters{FT} <: AbstractMicrophysicsParameters
     τ_precip::FT
     qc_0::FT
     S_0::FT
 end
-Base.@kwdef struct Microphysics_1M_Parameters{FT} <: AbstractMicrophysicsParameters
-    ...
-end
-```
-We omit their constructors (see above). The `CloudMicrophysics` parameter set is built likewise
 
-```julia
 Base.@kwdef struct CloudMicrophysicsParameters{FT, AMPS <: AbstractMicrophysicsParameters}
     K_therm::FT
-    ...
+    # ... other parameters
     MPS::AMPS
     TPS::ThermodynamicsParameters{FT}
 end
-
 
 function CloudMicrophysicsParameters(
     toml_dict,
@@ -167,50 +292,73 @@ function CloudMicrophysicsParameters(
     TPS::ThermodynamicsParameters{FT},
 ) where {FT, AMPS <: AbstractMicrophysicsParameters}
 
-    parameter_names = [ "K_therm", ... ]
+    parameter_names = ["K_therm", "other_param", ...]
 
-    parameters  = ClimaParams.get_parameter_values(
+    parameters = CP.get_parameter_values(
         toml_dict,
         parameter_names,
         "CloudMicrophysics",
     )
 
     return CloudMicrophysicsParameters{FT, AMPS}(;
-            parameters...,
-            MPS,  # Nested parameter struct
-            TPS,  # Nested parameter struct
-        )
+        parameters...,
+        MPS,  # Nested parameter struct
+        TPS,  # Nested parameter struct
+    )
 end
 ```
 
 ### Parameters-as-functions
 
-!!! note
-    The exact APIs here are subject to change.
+When building model components, parameters are extracted by calling `param_set.name`:
 
-When building the model components, parameters are extracted by calling `param_set.name`
 ```julia
-function example_cloudmicrophysics_func(param_set::CloudMicrophysicsParameters,...)
+function example_cloudmicrophysics_func(param_set::CloudMicrophysicsParameters, ...)
     K_therm = param_set.K_therm
-    ...
+    # ... use parameters
 end
 ```
-These parameters can be made into functions for added flexibility.
+
+These parameters can be made into functions for added flexibility:
+
 ```julia
 K_therm(param_set) = param_set.K_therm
 ```
-This can be useful for derived parameters,
+
+This can be useful for derived parameters:
+
 ```julia
 derived_param(param_set) = param_set.param1 * param_set.param2
 ```
-or to forward parameters from nested parameter structs:
+
+Or to forward parameters from nested parameter structs:
+
 ```julia
 forwarded_param(ps::ParamSet) = ps.nested_params.forwarded_param
 ```
 
 Functions can be autogenerated using `@eval`:
+
 ```julia
 for fn in fieldnames(ParamSet)
     @eval $(fn)(ps::ParamSet) = ps.$(fn)
 end
+```
+
+## Parameter Types
+
+ClimaParams supports several parameter types:
+
+- **Float**: Numeric values (default)
+- **Integer**: Whole numbers
+- **String**: Text values  
+- **Bool**: Boolean values
+
+The type is specified in the TOML file:
+
+```toml
+[gravitational_acceleration]
+value = 9.81
+type = "float"
+description = "Gravitational acceleration on the planet (m s⁻²)."
 ```

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1,2826 +1,2892 @@
 ## Land
 
-# AutotrophicRespiration parameters
+# Autotrophic Respiration parameters
 
 [N_factor_Vcmax25]
 value = 8e-4
 type = "float"
-description = "Vcmax25 to N factor (mol CO2 m-2 s-1 kg C (kg C)-1)"
+description = "Factor converting Vcmax at 25°C to nitrogen content (mol CO₂ m⁻² s⁻¹ kgC (kgC)⁻¹)."
 
 [live_stem_wood_coeff]
 value = 0.01
 type = "float"
-description = "Live stem wood coefficient (kg C m-3)"
+description = "Live stem wood coefficient (kg C m⁻³)."
 
 [specific_leaf_density]
 value = 0.05
 type = "float"
-description = "Specific leaf density (kg C m-2 [leaf])"
+description = "Specific leaf density (kg C m⁻² leaf)."
 
 [root_leaf_nitrogen_ratio]
-value = 1
+value = 1.0
 type = "float"
-description = "Ratio root nitrogen to top leaf nitrogen (unitless)"
+description = "Ratio of root nitrogen to top leaf nitrogen (unitless)."
 
 [stem_leaf_nitrogen_ratio]
 value = 0.1
 type = "float"
-description = "Ratio stem nitrogen to top leaf nitrogen (unitless)"
+description = "Ratio of stem nitrogen to top leaf nitrogen (unitless)."
 
 [relative_contribution_factor]
 value = 0.25
 type = "float"
-description = "Factor of relative contribution or Rgrowth (-)"
+description = "Factor of relative contribution for growth respiration, Rgrowth (unitless)."
 
-# Farquhar Parameters
+# Farquhar model parameters for photosynthesis
 
 [CO2_compensation_point_25c]
 value = 4.275e-5
 type = "float"
-description = "Γstar at 25 °C (mol/mol). Source: Bernacchi et al. (2001)"
+description = "CO₂ compensation point ($\\Gamma^*$) at 25°C (mol mol⁻¹). Source: Bernacchi et al. (2001)."
 
 [CO2_michaelis_menten]
 value = 4.049e-4
 type = "float"
-description = "Michaelis-Menten parameter for CO2 at 25 °C (mol/mol). Source: Bernacchi et al. (2001)"
+description = "Michaelis-Menten parameter for CO₂ at 25°C (mol mol⁻¹). Source: Bernacchi et al. (2001)."
 
 [O2_michaelis_menten]
 value = 0.2784
 type = "float"
-description = "Michaelis-Menten parameter for O2 at 25 °C (mol/mol). Source: Bernacchi et al. (2001)"
+description = "Michaelis-Menten parameter for O₂ at 25°C (mol mol⁻¹). Source: Bernacchi et al. (2001)."
 
 [CO2_activation_energy]
-value = 79430
+value = 79430.0
 type = "float"
-description = "Energy of activation for CO2 (J/mol). Source: Bonan (2019), Table 11.2 and Bernacchi et al. (2001, 2003)"
+description = "Energy of activation for CO₂ (J mol⁻¹). Source: Bonan (2019), Table 11.2; Bernacchi et al. (2001, 2003)."
 
 [O2_activation_energy]
-value = 36380
+value = 36380.0
 type = "float"
-description = "Energy of activation for oxygen (J/mol). Source: Bonan (2019), Table 11.2 and Bernacchi et al. (2001, 2003)"
+description = "Energy of activation for oxygen (J mol⁻¹). Source: Bonan (2019), Table 11.2; Bernacchi et al. (2001, 2003)."
 
 [Vcmax_activation_energy]
-value = 65330
+value = 65330.0
 type = "float"
-description = "Energy of activation for Vcmax (J/mol). Source: Bonan (2019), Table 11.2 and Bernacchi et al. (2001, 2003)"
+description = "Energy of activation for Vcmax (J mol⁻¹). Source: Bonan (2019), Table 11.2; Bernacchi et al. (2001, 2003)."
 
 ["Γstar_activation_energy"]
-value = 37830
+value = 37830.0
 type = "float"
-description = "Energy of activation for Γstar (J/mol). Source: Bonan (2019), Table 11.2 and Bernacchi et al. (2001, 2003)"
+description = "Energy of activation for $\\Gamma^*$ (J mol⁻¹). Source: Bonan (2019), Table 11.2; Bernacchi et al. (2001, 2003)."
 
 [Jmax_activation_energy]
-value = 43540
+value = 43540.0
 type = "float"
-description = "Energy of activation for Jmax (J/mol). Source: Bonan (2019), Table 11.2 and Bernacchi et al. (2001, 2003)"
+description = "Energy of activation for Jmax (J mol⁻¹). Source: Bonan (2019), Table 11.2; Bernacchi et al. (2001, 2003)."
 
 [Rd_activation_energy]
-value = 46390
+value = 46390.0
 type = "float"
-description = "Energy of activation for Rd (J/mol). Source: Bonan (2019), Table 11.2 and Bernacchi et al. (2001, 2003)"
+description = "Energy of activation for dark respiration, Rd (J mol⁻¹). Source: Bonan (2019), Table 11.2; Bernacchi et al. (2001, 2003)."
 
 [kelvin_25C]
 value = 298.15
 type = "float"
-description = "Reference temperature equal to 25 degrees Celsius (K)"
+description = "Reference temperature equal to 25°C (K)."
 
 [intercellular_O2_concentration]
 value = 0.209
 type = "float"
-description = "Intercelluar O2 concentration (mol/mol); taken to be constant"
+description = "Intercellular O₂ concentration, assumed constant (mol mol⁻¹)."
 
 [photosystem_II_quantum_yield]
 value = 0.7
 type = "float"
-description = "Quantum yield of photosystem II (unitless). Source: Bonan (2019), Bernacchi (2003)"
+description = "Quantum yield of photosystem II (unitless). Source: Bonan (2019); Bernacchi (2003)."
 
 [Farquhar_curvature_parameter]
 value = 0.9
 type = "float"
-description = "Curvature parameter, a fitting constant to compute J, unitless. Source: von Caemmerer 2000,2013; Bernacchi et al.2003,2013; von Caemmerer et al. 2009"
+description = "Curvature parameter for calculating J, a unitless fitting constant. Source: von Caemmerer (2000, 2013); Bernacchi et al. (2003, 2013); von Caemmerer et al. (2009)."
 
 [dark_respiration_factor]
 value = 0.015
 type = "float"
-description = "Constant factor appearing in the dark respiration term. Source: Climate Change and Terrestrial Ecosystem Modeling (2019)."
+description = "Constant factor appearing in the dark respiration term (unitless). Source: Bonan (2019)."
 
 [low_water_pressure_sensitivity]
 value = 5e-6
 type = "float"
+description = "Sensitivity of stomatal conductance to low water pressure (Pa⁻¹)."
 
 [moisture_stress_ref_water_pressure]
 value = -2e6
 type = "float"
-description = "Reference water pressure for the moisture stress factor (Pa) [Tuzet et al. (2003)]"
+description = "Reference water pressure for the moisture stress factor (Pa). Source: Tuzet et al. (2003)."
 
 [electron_transport_maintenance]
 value = 0.05336251
 type = "float"
-description = "Constant describing cost of maintaining electron transport (unitless)"
+description = "Constant describing the cost of maintaining electron transport (unitless)."
 
 # SoilCO2Model
 
 [kg_C_to_mol_CO2_factor]
 value = 83.26
 type = "float"
-description = "Conversion factor from kg C to mol CO2"
+description = "Conversion factor from kg C to mol CO₂."
 
 [CO2_diffusion_coefficient]
 value = 1.39e-5
 type = "float"
-description = "Diffusion coefficient for CO₂ in air at standard temperature and pressure (m² s⁻¹). Source: Ryan et al. (2018). DOI: https://doi.org/10.5194/gmd-11-1909-2018"
+description = "Diffusion coefficient for CO₂ in air at standard temperature and pressure (m² s⁻¹). Source: Ryan et al. (2018), DOI: 10.5194/gmd-11-1909-2018."
 
 [oxygen_diffusion_coefficient]
 value = 1.67
 type = "float"
-description = "Diffusion coefficient of oxygen in air, dimensionless. Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Diffusion coefficient of oxygen in air (dimensionless). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
 [soil_C_substrate_diffusivity]
 value = 3.17
 type = "float"
-description = "Diffusivity of soil C substrate in liquid (unitless). Source: Ryan et al. (2018). DOI: https://doi.org/10.5194/gmd-11-1909-2018"
+description = "Diffusivity of soil C substrate in liquid (unitless). Source: Ryan et al. (2018), DOI: 10.5194/gmd-11-1909-2018."
 
-[soilCO2_pre_expontential_factor]
+[soilCO2_pre_exponential_factor]
 value = 194e3
 type = "float"
-description = "Pre-exponential factor (kg C m-3 s-1). Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Pre-exponential factor for soil CO₂ model (kg C m⁻³ s⁻¹). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
 [soilCO2_activation_energy]
 value = 61e3
 type = "float"
-description = "Activation energy (J mol-1). Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Activation energy for soil CO₂ model (J mol⁻¹). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
 [michaelis_constant]
 value = 5e-3
 type = "float"
-description = "Michaelis constant (kg C m-3). Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Michaelis constant (kg C m⁻³). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
 [O2_michaelis_constant]
-value = 0.004
+value = 4e-3
 type = "float"
-description = "Michaelis constant for O2 (m3 m-3). Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Michaelis constant for O₂ (m³ m⁻³). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
 [O2_volume_fraction]
 value = 0.209
 type = "float"
-description = "Volumetric fraction of O₂ in the soil air, dimensionless. Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Volumetric fraction of O₂ in the soil air (dimensionless). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
 [soluble_soil_carbon_fraction]
 value = 0.024
 type = "float"
-description = "Fraction of soil carbon that is considered soluble, dimensionless. Source: Davidson et al. (2011). DOI: https://doi.org/10.1111/j.1365-2486.2011.02546.x"
+description = "Fraction of soil carbon that is considered soluble (dimensionless). Source: Davidson et al. (2011), DOI: 10.1111/j.1365-2486.2011.02546.x."
 
-# Soil model
+# Soil Model
 
 [thermal_conductivity_of_quartz]
 value = 8.0
 type = "float"
-description = "[W/m/K]; see Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "Thermal conductivity of quartz (W m⁻¹ K⁻¹). Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [thermal_conductivity_of_soil_minerals]
 value = 2.5
 type = "float"
-description = "[W/m/K]. Not including quartz; see Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "Thermal conductivity of soil minerals, excluding quartz (W m⁻¹ K⁻¹). Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [thermal_conductivity_of_organic_matter]
 value = 0.25
 type = "float"
-description = "[W/m/K]; see Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "Thermal conductivity of organic matter (W m⁻¹ K⁻¹). Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [thermal_conductivity_of_liquid_water]
 value = 0.57
 type = "float"
-description = "[W/m/K]. At 10 degrees C; see Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "Thermal conductivity of liquid water at 10°C (W m⁻¹ K⁻¹). Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [thermal_conductivity_of_water_ice]
 value = 2.21
 type = "float"
-description = "[W/m/K]. At the freezing temperature of water; see Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "Thermal conductivity of water ice at its freezing temperature (W m⁻¹ K⁻¹). Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [kersten_number_alpha]
 value = 0.24
 type = "float"
-description = "fit unitless constant used in computing the Kersten number; See Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "A unitless empirical constant ($\\alpha$) used in computing the Kersten number. Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [kersten_number_beta]
 value = 18.3
 type = "float"
-description = "fit unitless constant used in computing the Kersten number; See Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
+description = "A unitless empirical constant ($\\beta$) used in computing the Kersten number. Source: Balland and Arp, J. Environ. Eng. Sci. 4: 549-558 (2005)."
 
 [ice_impedance_omega]
 value = 7.0
 type = "float"
-description = "Unitless parameter used to adjust soil hydraulic conductivity when ice is present; see Lundin J. Hydrol. (Amsterdam) 118:289–310. (1990)"
+description = "A unitless impedance parameter ($\\Omega$) used to adjust soil hydraulic conductivity for ice presence. Source: Lundin, J. Hydrol. 118:289-310 (1990)."
 
 [temperature_factor_soil_hydraulic_conductivity]
 value = 0.0264
 type = "float"
-description = "Empirical parameter [1/K] used to adjust soil hydraulic conductivity given soil temperature."
+description = "An empirical parameter for adjusting soil hydraulic conductivity based on temperature (K⁻¹)."
 
 [temperature_reference_soil_hydraulic_conductivity]
 value = 288
 type = "float"
-description = "Reference temperature (K) used to adjust soil hydraulic conductivity given soil temperature."
+description = "The reference temperature for adjusting soil hydraulic conductivity (K)."
 
 [maximum_dry_soil_layer_depth]
 value = 0.015
 type = "float"
-description = "Maximum depth of the dry soil layer that develops under evaporation; communication with Dani Or."
+description = "Maximum depth of the dry soil layer that can develop under evaporation (m). Source: Shokri and Or (2011), DOI: 10.1029/2010WR010284"
 
 [emissivity_bare_soil]
 value = 0.96
 type = "float"
-description = "Emissivity of soil, approximated as context. Reference: CLM5 Documentation, 2020. "
+description = "Emissivity of bare soil (unitless). Source: CLM5 Technical Note (2020)."
 
 # Energy Hydrology Parameters
 
 [soil_momentum_roughness_length]
 value = 0.01
 type = "float"
-description = "Source: CLM Tech note 5"
+description = "Momentum roughness length for soil (m). Source: CLM5 Technical Note."
 
 [soil_scalar_roughness_length]
-value = 0.007
+value = 7e-3
 type = "float"
-description = "Source: CLM Tech note 5, using u* of 5m/s"
+description = "Scalar roughness length for soil (m), assuming friction velocity $u_*$ of 5 m s⁻¹. Source: CLM5 Technical Note."
 
 [snow_momentum_roughness_length]
-value = 0.0024
+value = 2.4e-3
 type = "float"
-description = "Source: CLM Tech note 5"
+description = "Momentum roughness length for snow (m). Source: CLM5 Technical Note."
 
 [snow_scalar_roughness_length]
-value = 0.08
+value = 8e-2
 type = "float"
-description = "Source: CLM Tech note 5, using u* of 5m/s"
+description = "Scalar roughness length for snow (m), assuming friction velocity $u_*$ of 5 m s⁻¹. Source: CLM5 Technical Note."
 
 [particle_density_quartz]
 value = 2.66e3
 type = "float"
-description = "Source: Hillel (1982), De Vries (1966)"
+description = "Particle density of quartz (kg m⁻³). Source: Hillel (1982); De Vries (1966)."
 
 [particle_density_minerals]
 value = 2.65e3
 type = "float"
-description = "Source: Hillel (1982)"
+description = "Particle density of soil minerals (kg m⁻³). Source: Hillel (1982)."
 
 [particle_density_organic_matter]
 value = 1.3e3
 type = "float"
-description = "Source: Hillel (1982)"
+description = "Particle density of organic matter (kg m⁻³). Source: Hillel (1982)."
 
 [vol_heat_capacity_quartz]
 value = 2.01e6
 type = "float"
-description = "Source: Balland and Arp (2005)"
+description = "Volumetric heat capacity of quartz (J m⁻³ K⁻¹). Source: Balland and Arp (2005)."
 
 [vol_heat_capacity_organic_matter]
 value = 2.51e6
 type = "float"
-description = "Source: Balland and Arp (2005)"
+description = "Volumetric heat capacity of organic matter (J m⁻³ K⁻¹). Source: Balland and Arp (2005)."
 
 [vol_heat_capacity_minerals]
 value = 2.01e6
 type = "float"
-description = "Source: Balland and Arp (2005)"
+description = "Volumetric heat capacity of soil minerals excluding quartz (J m⁻³ K⁻¹). Source: Balland and Arp (2005)."
 
 # Bucket Model
 
 [soil_conductivity]
 value = 1.5
 type = "float"
-description = "Conductivity of the soil (W/K/m); constant. Source: SLIM model (Laguë et al 2019)"
+description = "Constant conductivity of the soil (W m⁻¹ K⁻¹). Source: SLIM model, Laguë et al. (2019)."
 
 [soil_heat_capacity]
 value = 2e6
 type = "float"
-description = "Volumetric heat capacity of the soil (J/m^3/K). Source: SLIM model (Laguë et al 2019)"
+description = "Volumetric heat capacity of the soil (J m⁻³ K⁻¹). Source: SLIM model, Laguë et al. (2019)."
 
 [critical_snow_water_equivalent]
 value = 0.05
 type = "float"
-description = "Critical σSWE amount (m) where surface transitions to snow-covered. Source: SLIM model (Laguë et al 2019)"
+description = "Critical snow water equivalent ($\\sigma_{SWE}$) at which the surface transitions to fully snow-covered (m). Source: SLIM model, Laguë et al. (2019)."
 
 [land_bucket_capacity]
 value = 0.2
 type = "float"
-description = "Capacity of the land bucket (m). Source: SLIM model (Laguë et al 2019)"
+description = "Water capacity of the land bucket (m). Source: SLIM model, Laguë et al. (2019)."
 
 [critical_snow_fraction]
 value = 0.0
 type = "float"
-description = "Fraction of critical amount of snow at which sublimation β begins to decay to zero (unitless). Source: SLIM model (Laguë et al 2019)"
+description = "Fraction of the critical snow amount at which the sublimation factor ($\\beta$) begins to decay to zero (unitless). Source: SLIM model, Laguë et al. (2019)."
 
 [bucket_capacity_fraction]
 value = 0.75
 type = "float"
-description = "Fraction of bucket capacity at which evaporation β begins to decay to zero (unitless). Source: SLIM model (Laguë et al 2019)"
+description = "Fraction of the bucket capacity at which the evaporation factor ($\\beta$) begins to decay to zero (unitless). Source: SLIM model, Laguë et al. (2019)."
 
 [bucket_beta_decay_exponent]
 value = 1
 type = "float"
-description = "Exponent used in β decay (unitless). Source: SLIM model (Laguë et al 2019)"
+description = "Exponent used in the decay of the evaporation/sublimation factor ($\\beta$) (unitless). Source: SLIM model, Laguë et al. (2019)."
 
 # Snow
 
 [snow_density]
 value = 200
 type = "float"
-description = "Density of snow (kg/m^3)"
+description = "Density of snow (kg m⁻³)."
 
 [snow_albedo]
 value = 0.8
 type = "float"
-description = "Albedo of snow (unitless)"
+description = "Albedo of snow (unitless)."
 
 [snow_emissivity]
 value = 0.97
 type = "float"
-description = "Emissivity of snow (unitless). Source: CLM Tech note 5"
+description = "Emissivity of snow (unitless). Source: CLM5 Technical Note."
 
 [holding_capacity_of_water_in_snow]
 value = 0.08
 type = "float"
-description = "Volumetric holding capacity of water in snow (unitless)"
+description = "Volumetric holding capacity of liquid water in a snowpack (unitless)."
 
 [wet_snow_hydraulic_conductivity]
 value = 1e-3
 type = "float"
-description = "Hydraulic conductivity of wet snow (m/s)"
+description = "Hydraulic conductivity of wet snow (m s⁻¹)."
 
 [snow_cover_fraction_crit_threshold]
 value = 0.2
 type = "float"
-description = "Critical threshold for snow cover fraction (m)"
+description = "Critical threshold for determining snow cover fraction (m)."
 
 # Two Stream/Beer Lambert Parameters
 
 [wavelength_per_PAR_photon]
 value = 5e-7
 type = "float"
-description = "Typical wavelength per PAR photon (m)"
+description = "Typical wavelength of a photon in the Photosynthetically Active Radiation (PAR) band (m)."
 
 [wavelength_per_NIR_photon]
 value = 1.65e-6
 type = "float"
-description = "Typical wavelength per NIR photon (m)"
+description = "Typical wavelength of a photon in the Near-Infrared (NIR) band (m)."
 
 [canopy_emissivity]
 value = 0.97
 type = "float"
-description = "Emissivity of the canopy"
+description = "Emissivity of the canopy (unitless)."
 
 # Medlyn Conductance
 
 [relative_diffusivity_of_water_vapor]
 value = 1.6
 type = "float"
-description = "Relative diffusivity of water vapor (unitless)"
+description = "Relative diffusivity of water vapor compared to heat (unitless)."
 
 [min_stomatal_conductance]
 value = 1e-4
 type = "float"
-description = "Minimum stomatal conductance mol/m^2/s"
-
+description = "Minimum stomatal conductance (mol m⁻² s⁻¹)."
 
 ## Surface Fluxes
 
 [richardson_critical]
 value = 1.0
 type = "float"
-description = "Critical Richardson number, stable mixing cutoff. Ref: Frierson et al (2006) https://doi.org/10.1175/JAS3753.1"
+description = "The critical Richardson number ($Ri_{crit}$), a unitless parameter defining the cutoff for stable mixing. Source: Frierson et al. (2006), DOI: 10.1175/JAS3753.1."
 
 [surface_layer_fraction]
 value = 0.1
 type = "float"
-description = "Surface layer thickness as a fraction of the planetary boundary layer. Ref: Frierson et al (2006) https://doi.org/10.1175/JAS3753.1"
+description = "The surface layer thickness as a fraction of the planetary boundary layer height (unitless). Source: Frierson et al. (2006), DOI: 10.1175/JAS3753.1."
 
 [gustiness]
 value = 1.0
 type = "float"
-description = "Near-surface gustiness[m/s]."
+description = "A parameter accounting for near-surface gustiness (m s⁻¹)."
 
 # Businger
 
 [prandtl_number_0_businger]
 value = 0.74
 type = "float"
-description = "Pr_0 for Businger universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "The turbulent Prandtl number in neutral conditions ($Pr_0$) for the Businger universal functions (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 [coefficient_a_m_businger]
 value = 4.7
 type = "float"
-description = "a_m for Businger momentum universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "Coefficient $a_m$ for the Businger momentum universal function (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 [coefficient_b_m_businger]
 value = 15.0
 type = "float"
-description = "b_m for Businger momentum universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "Coefficient $b_m$ for the Businger momentum universal function (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 [coefficient_a_h_businger]
 value = 4.7
 type = "float"
-description = "a_h for Businger heat universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "Coefficient $a_h$ for the Businger heat universal function (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 [coefficient_b_h_businger]
 value = 9.0
 type = "float"
-description = "b_h for Businger heat universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "Coefficient $b_h$ for the Businger heat universal function (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 [most_stability_parameter_businger]
 value = 2.5
 type = "float"
-description = "ζ_a for Businger universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "The MOST stability parameter ($\\zeta_a$) for the Businger universal functions (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 [most_stability_exponent_businger]
 value = 4.42
 type = "float"
-description = "γ for Businger universal functions. From Businger et al, 1971. DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
+description = "The MOST stability exponent ($\\gamma$) for the Businger universal functions (unitless). Source: Businger et al. (1971), DOI: 10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2."
 
 # Gryanik
 
 [prandtl_number_0_gryanik]
 value = 0.98
 type = "float"
-description = "Pr_0 for Gryanik universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "The turbulent Prandtl number in neutral conditions ($Pr_0$) for the Gryanik universal functions (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 [coefficient_a_m_gryanik]
 value = 5.0
 type = "float"
-description = "a_m for Gryanik momentum universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "Coefficient $a_m$ for the Gryanik momentum universal function (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 [coefficient_a_h_gryanik]
 value = 5.0
 type = "float"
-description = "a_h for Gryanik heat universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "Coefficient $a_h$ for the Gryanik heat universal function (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 [coefficient_b_m_gryanik]
 value = 0.3
 type = "float"
-description = "b_m for Gryanik momentum universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "Coefficient $b_m$ for the Gryanik momentum universal function (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 [coefficient_b_h_gryanik]
 value = 0.4
 type = "float"
-description = "b_h for Gryanik heat universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "Coefficient $b_h$ for the Gryanik heat universal function (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 [most_stability_parameter_gryanik]
 value = 7.25
 type = "float"
-description = "ζ_a for Gryanik universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "The MOST stability parameter ($\\zeta_a$) for the Gryanik universal functions (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 [most_stability_exponent_gryanik]
 value = 3.62
 type = "float"
-description = "γ for Gryanik universal functions. From Gryanik et al, 2020. DOI: 10.1175/JAS-D-19-0255.1"
+description = "The MOST stability exponent ($\\gamma$) for the Gryanik universal functions (unitless). Source: Gryanik et al. (2020), DOI: 10.1175/JAS-D-19-0255.1."
 
 # Grachev
 
 [prandtl_number_0_grachev]
 value = 0.98
 type = "float"
-description = "Pr_0 for Grachev universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "The turbulent Prandtl number in neutral conditions ($Pr_0$) for the Grachev universal functions (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [coefficient_a_m_grachev]
 value = 5.0
 type = "float"
-description = "a_m for Grachev momentum universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "Coefficient $a_m$ for the Grachev momentum universal function (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [coefficient_a_h_grachev]
 value = 5.0
 type = "float"
-description = "a_h for Grachev heat universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "Coefficient $a_h$ for the Grachev heat universal function (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [coefficient_b_m_grachev]
 value = 0.7692307692307693
 type = "float"
-description = "derived b_m = [coefficient_a_m_grachev] / 6.5 for Grachev momentum universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "Derived coefficient $b_m$ for the Grachev momentum universal function, calculated as $a_m / 6.5$ (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [coefficient_b_h_grachev]
 value = 5.0
 type = "float"
-description = "b_h for Grachev heat universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "Coefficient $b_h$ for the Grachev heat universal function (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [coefficient_c_h_grachev]
 value = 3.0
 type = "float"
-description = "c_h for Grachev heat universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "Coefficient $c_h$ for the Grachev heat universal function (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [most_stability_parameter_grachev]
 value = 3.6
 type = "float"
-description = "ζ_a for Grachev universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "The MOST stability parameter ($\\zeta_a$) for the Grachev universal functions (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 [most_stability_exponent_grachev]
 value = 2.92
 type = "float"
-description = "γ for Grachev universal functions. From Grachev et al, 2007. DOI: 10.1007/s10546-007-9177-6"
+description = "The MOST stability exponent ($\\gamma$) for the Grachev universal functions (unitless). Source: Grachev et al. (2007), DOI: 10.1007/s10546-007-9177-6."
 
 # Cheng
 
 [prandtl_number_0_cheng]
 value = 1.0
 type = "float"
-description = "Pr_0 for Cheng universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
+description = "The turbulent Prandtl number in neutral conditions ($Pr_0$) for the Cheng universal functions (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 [coefficient_a_m_cheng]
 value = 6.1
 type = "float"
-description = "a_m for Cheng momentum universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
+description = "Coefficient $a_m$ for the Cheng momentum universal function (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 [coefficient_a_h_cheng]
 value = 5.3
 type = "float"
-description = "a_h for Cheng heat universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
+description = "Coefficient $a_h$ for the Cheng heat universal function (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 [coefficient_b_m_cheng]
 value = 2.5
 type = "float"
-description = "b_m for Cheng momentum universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
+description = "Coefficient $b_m$ for the Cheng momentum universal function (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 [coefficient_b_h_cheng]
 value = 1.1
 type = "float"
-description = "b_h for Cheng heat universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
+description = "Coefficient $b_h$ for the Cheng heat universal function (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 [most_stability_parameter_cheng]
 value = 4.5
 type = "float"
-description = "ζ for Cheng universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
+description = "The MOST stability parameter ($\\zeta$) for the Cheng universal functions (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 [most_stability_exponent_cheng]
 value = 2.28
 type = "float"
-description = "γ for Cheng universal functions. From Cheng et al, 2005. DOI: 10.1007/s10546-004-1425-4"
-
+description = "The MOST stability exponent ($\\gamma$) for the Cheng universal functions (unitless). Source: Cheng et al. (2005), DOI: 10.1007/s10546-004-1425-4."
 
 # Holtslag
 
 [prandtl_number_0_holtslag]
 value = 1.0
 type = "float"
-description = "Pr_0 for Holtslag universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "The turbulent Prandtl number in neutral conditions ($Pr_0$) for the Holtslag universal functions (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_a_m_holtslag]
 value = 0.7
 type = "float"
-description = "a_m for Holtslag momentum universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $a_m$ for the Holtslag momentum universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_a_h_holtslag]
 value = 0.7
 type = "float"
-description = "a_h for Holtslag heat universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $a_h$ for the Holtslag heat universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_b_m_holtslag]
 value = 0.75
 type = "float"
-description = "b_m for Holtslag momentum universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $b_m$ for the Holtslag momentum universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_b_h_holtslag]
 value = 0.75
 type = "float"
-description = "b_h for Holtslag heat universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $b_h$ for the Holtslag heat universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_c_m_holtslag]
 value = 5.0
 type = "float"
-description = "c_m for Holtslag momentum universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $c_m$ for the Holtslag momentum universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_c_h_holtslag]
 value = 5.0
 type = "float"
-description = "c_h for Holtslag heat universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $c_h$ for the Holtslag heat universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_d_m_holtslag]
 value = 0.35
 type = "float"
-description = "d_m for Holtslag momentum universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $d_m$ for the Holtslag momentum universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [coefficient_d_h_holtslag]
 value = 0.35
 type = "float"
-description = "d_h for Holtslag heat universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "Coefficient $d_h$ for the Holtslag heat universal function (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [most_stability_parameter_holtslag]
 value = 4.0
 type = "float"
-description = "ζ_a for Holtslag universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
+description = "The MOST stability parameter ($\\zeta_a$) for the Holtslag universal functions (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 [most_stability_exponent_holtslag]
 value = 2.14
 type = "float"
-description = "γ for Holtslag universal functions. From Holtslag et al, 1988. DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2"
-
+description = "The MOST stability exponent ($\\gamma$) for the Holtslag universal functions (unitless). Source: Holtslag et al. (1988), DOI: 10.1175/1520-0450(1988)027<0689:AMOTNS>2.0.CO;2."
 
 # Beljaars
 
 [prandtl_number_0_beljaars]
 value = 1.0
 type = "float"
-description = "Pr_0 for Beljaars universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "The turbulent Prandtl number in neutral conditions ($Pr_0$) for the Beljaars universal functions (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_a_m_beljaars]
 value = 1.0
 type = "float"
-description = "a_m for Beljaars momentum universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $a_m$ for the Beljaars momentum universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_a_h_beljaars]
 value = 1.0
 type = "float"
-description = "a_h for Beljaars heat universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $a_h$ for the Beljaars heat universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_b_m_beljaars]
 value = 0.667
 type = "float"
-description = "b_m for Beljaars momentum universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $b_m$ for the Beljaars momentum universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_b_h_beljaars]
 value = 0.667
 type = "float"
-description = "b_h for Beljaars heat universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $b_h$ for the Beljaars heat universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_c_m_beljaars]
 value = 5.0
 type = "float"
-description = "c_m for Beljaars momentum universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $c_m$ for the Beljaars momentum universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_c_h_beljaars]
 value = 5.0
 type = "float"
-description = "c_h for Beljaars heat universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $c_h$ for the Beljaars heat universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_d_m_beljaars]
 value = 0.35
 type = "float"
-description = "d_m for Beljaars momentum universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $d_m$ for the Beljaars momentum universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [coefficient_d_h_beljaars]
 value = 0.35
 type = "float"
-description = "d_h for Beljaars heat universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "Coefficient $d_h$ for the Beljaars heat universal function (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [most_stability_parameter_beljaars]
 value = 3.4
 type = "float"
-description = "ζ_a for Beljaars universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "The MOST stability parameter ($\\zeta_a$) for the Beljaars universal functions (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [most_stability_exponent_beljaars]
 value = 2.04
 type = "float"
-description = "γ for Beljaars universal functions. From Beljaars et al, 1991. DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2"
+description = "The MOST stability exponent ($\\gamma$) for the Beljaars universal functions (unitless). Source: Beljaars et al. (1991), DOI: 10.1175/1520-0450(1991)030<0327:FPOLSF>2.0.CO;2."
 
 [von_karman_constant]
 value = 0.4
 type = "float"
+description = "The von Kármán constant ($\\kappa$), a dimensionless constant describing the logarithmic velocity profile near a boundary."
 
 # Microphysics
-
 
 [precipitation_timescale]
 value = 1000
 type = "float"
-description = "0-moment microphysics precipitation formation timescale [s]"
+description = "Precipitation formation timescale for the 0-moment microphysics scheme (s)."
 
 [specific_humidity_precipitation_threshold]
 value = 5e-6
 type = "float"
-description = "0-moment microphysics precipitation formation threshold as specific humidity [-]"
+description = "Precipitation formation threshold in terms of specific humidity for the 0-moment microphysics scheme (unitless)."
 
 [supersaturation_precipitation_threshold]
 value = 0.02
 type = "float"
-description = "0-moment microphysics precipitation formation threshold as supersaturation [-]"
+description = "Precipitation formation threshold in terms of supersaturation for the 0-moment microphysics scheme (unitless)."
 
 [rain_drop_drag_coefficient]
 value = 0.55
 type = "float"
-description = "1-moment microphysics rain drop drag coefficient [-]"
+description = "Rain drop drag coefficient for the 1-moment microphysics scheme (unitless)."
 
-[thermal_conductivity_of_air ]
+[thermal_conductivity_of_air]
 value = 0.024
 type = "float"
-description = "thermal conductivity of air [J/m/s/K]"
+description = "Thermal conductivity of air (J m⁻¹ s⁻¹ K⁻¹)."
 
 [diffusivity_of_water_vapor]
-value = 0.0000226
+value = 2.26e-5
 type = "float"
-description = "diffusivity of water vapor [m^2/s]"
+description = "Diffusivity of water vapor in air (m² s⁻¹)."
 
 [kinematic_viscosity_of_air]
-value = 0.000016
+value = 1.6e-5
 type = "float"
-description = "kinematic viscosity of air [m^2/s]"
+description = "Kinematic viscosity of air (m² s⁻¹)."
 
 [condensation_evaporation_timescale]
-value = 10
+value = 10.0
 type = "float"
-description = "Non-equilibrium microphysics condensation/evaporation time scale [s]"
+description = "Condensation/evaporation timescale for non-equilibrium microphysics (s)."
 
 [liquid_cloud_effective_radius]
 value = 14e-6
 type = "float"
-description = "Constant assumed liquid cloud effective radius [m]"
+description = "Assumed constant effective radius for liquid cloud droplets (m)."
 
 [ice_cloud_effective_radius]
 value = 25e-6
 type = "float"
-description = "Constant assumed ice cloud effective radius [m]"
+description = "Assumed constant effective radius for ice cloud particles (m)."
 
 [sublimation_deposition_timescale]
-value = 10
+value = 10.0
 type = "float"
-description = "Non-equilibrium microphysics deposition/sublimation time scale [s]"
+description = "Deposition/sublimation timescale for non-equilibrium microphysics (s)."
 
 [ice_snow_threshold_radius]
 value = 6.25e-5
 type = "float"
-description = "1-moment microphysics threshold particle radius between ice and snow [m]"
+description = "Threshold particle radius separating ice and snow for the 1-moment microphysics scheme (m)."
 
 [cloud_ice_size_distribution_coefficient_n0]
 value = 2e7
 type = "float"
-description = "1-moment microphysics cloud ice size distribution parameter [1/m^4]"
+description = "Cloud ice size distribution parameter $n_0$ for the 1-moment microphysics scheme (m⁻⁴)."
 
 [cloud_ice_crystals_length_scale]
-value = 0.00001
+value = 1.0e-5
 type = "float"
-description = "1-moment microphysics cloud ice particle length scale [m]"
+description = "Cloud ice particle length scale for the 1-moment microphysics scheme (m)."
 
 [cloud_ice_mass_size_relation_coefficient_me]
 value = 3
 type = "float"
-description = "1-moment microphysics cloud ice mass(radius) coefficient [-]"
+description = "Exponent $m_e$ in the mass-size relation for cloud ice in the 1-moment microphysics scheme (unitless)."
 
 [cloud_ice_mass_size_relation_coefficient_chim]
 value = 1
 type = "float"
-description = "1-moment microphysics cloud ice mass(radius) coefficient [-]"
+description = "Coefficient $\\chi_m$ in the mass-size relation for cloud ice in the 1-moment microphysics scheme (unitless)."
 
 [cloud_ice_mass_size_relation_coefficient_delm]
 value = 0
 type = "float"
-description = "1-moment microphysics cloud ice mass(radius) coefficient [-]"
+description = "Coefficient $\\delta_m$ in the mass-size relation for cloud ice in the 1-moment microphysics scheme (unitless)."
 
 [cloud_liquid_water_specific_humidity_autoconversion_threshold]
-value = 0.0005
+value = 5e-4
 type = "float"
-description = "1-moment microphysics rain formation threshold as specific humidity [-]"
+description = "Rain formation threshold in terms of specific humidity for the 1-moment microphysics scheme (unitless)."
 
 [rain_autoconversion_timescale]
-value = 1000
+value = 1000.0
 type = "float"
-description = "1-moment microphysics rain formation timescale [s]"
+description = "Rain formation timescale for the 1-moment microphysics scheme (s)."
 
-[rain_ventillation_coefficient_a]
+[rain_ventilation_coefficient_a]
 value = 1.5
 type = "float"
-description = "1-moment microphysics rain ventilation coefficient [-]"
+description = "Rain ventilation coefficient 'a' for the 1-moment microphysics scheme (unitless)."
 
-[rain_ventillation_coefficient_b ]
+[rain_ventilation_coefficient_b]
 value = 0.53
 type = "float"
-description = "1-moment microphysics rain ventilation coefficient [-]"
+description = "Rain ventilation coefficient 'b' for the 1-moment microphysics scheme (unitless)."
 
 [rain_drop_size_distribution_coefficient_n0]
 value = 1.6e7
 type = "float"
-description = "1-moment microphysics rain size distribution coefficient [1/m^4]"
+description = "Rain drop size distribution coefficient $n_0$ for the 1-moment microphysics scheme (m⁻⁴)."
 
 [rain_drop_length_scale]
-value = 0.001
+value = 1e-3
 type = "float"
-description = "1-moment microphysics rain drop length scale [m]"
+description = "Rain drop length scale for the 1-moment microphysics scheme (m)."
 
 [rain_minimum_inverse_lambda]
 value = 1e-8
 type = "float"
-description = "1-moment microphysics minimum value for the inverse of the shape parameter of rain drop size distribution [m]"
+description = "Minimum value for the inverse of the shape parameter $\\lambda$ of the rain drop size distribution (m)."
 
 [rain_mass_size_relation_coefficient_me]
 value = 3
 type = "float"
-description = "1-moment microphysics rain drop mass(radius) coefficient [-]"
+description = "Exponent $m_e$ in the mass-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_cross_section_size_relation_coefficient_ae]
 value = 2
 type = "float"
-description = "1-moment microphysics rain drop cross section(radius) coefficient [-]"
+description = "Exponent $a_e$ in the cross section-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_terminal_velocity_size_relation_coefficient_ve]
 value = 0.5
 type = "float"
-description = "1-moment microphysics rain drop terminal velocity(radius) coefficient [-]"
+description = "Exponent $v_e$ in the terminal velocity-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_mass_size_relation_coefficient_chim]
 value = 1
 type = "float"
-description = "1-moment microphysics rain drop mass(radius) coefficient [-]"
+description = "Coefficient $\\chi_m$ in the mass-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_mass_size_relation_coefficient_delm]
 value = 0
 type = "float"
-description = "1-moment microphysics rain drop mass(radius) coefficient [-]"
+description = "Coefficient $\\delta_m$ in the mass-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_cross_section_size_relation_coefficient_chia]
 value = 1
 type = "float"
-description = "1-moment microphysics rain drop cross section(radius) coefficient [-]"
+description = "Coefficient $\\chi_a$ in the cross section-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_cross_section_size_relation_coefficient_dela]
 value = 0
 type = "float"
-description = "1-moment microphysics rain drop cross section(radius) coefficient [-]"
+description = "Coefficient $\\delta_a$ in the cross section-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_terminal_velocity_size_relation_coefficient_chiv]
 value = 1
 type = "float"
-description = "1-moment microphysics rain drop terminal velocity(radius) coefficient [-]"
+description = "Coefficient $\\chi_v$ in the terminal velocity-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [rain_terminal_velocity_size_relation_coefficient_delv]
 value = 0
 type = "float"
-description = "1-moment microphysics rain drop terminal velocity(radius) coefficient [-]"
+description = "Coefficient $\\delta_v$ in the terminal velocity-size relation for rain in the 1-moment microphysics scheme (unitless)."
 
 [cloud_ice_apparent_density]
 value = 500
 type = "float"
-description = "The apparent density of cloud ice particles, from doi:10.1029/2020JD034157 [kg/m3]"
+description = "The apparent density of cloud ice particles (kg m⁻³). Source: DOI: 10.1029/2020JD034157."
 
 [snow_apparent_density]
 value = 100
 type = "float"
-description = "The apparent density of snow particles, from doi:10.1029/2020JD034157 [kg/m3]"
+description = "The apparent density of snow particles (kg m⁻³). Source: DOI: 10.1029/2020JD034157."
 
 [cloud_ice_specific_humidity_autoconversion_threshold]
-value = 0.000001
+value = 1e-6
 type = "float"
-description = "1-moment microphysics snow autoconversion threshold as specific humidity [-]"
+description = "Snow autoconversion threshold in terms of specific humidity for the 1-moment microphysics scheme (unitless)."
 
 [snow_autoconversion_timescale]
 value = 100
 type = "float"
-description = "1-moment microphysics snow autoconversion timescale [s]"
+description = "Snow autoconversion timescale for the 1-moment microphysics scheme (s)."
 
-[snow_ventillation_coefficient_a]
+[snow_ventilation_coefficient_a]
 value = 0.65
 type = "float"
-description = "1-moment microphysics snow ventilation coefficient [-]"
+description = "Snow ventilation coefficient 'a' for the 1-moment microphysics scheme (unitless)."
 
-[snow_ventillation_coefficient_b]
+[snow_ventilation_coefficient_b]
 value = 0.44
 type = "float"
-description = "1-moment microphysics snow ventilation coefficient [-]"
+description = "Snow ventilation coefficient 'b' for the 1-moment microphysics scheme (unitless)."
 
 [snow_flake_size_distribution_coefficient_mu]
 value = 4.36e9
 type = "float"
-description = "1-moment microphysics snow size distribution coefficient [1/m^4]"
+description = "Snow size distribution coefficient $\\mu$ for the 1-moment microphysics scheme (m⁻⁴)."
 
 [snow_flake_size_distribution_coefficient_nu]
 value = 0.63
 type = "float"
-description = "1-moment microphysics snow size distribution coefficient [-]"
+description = "Snow size distribution coefficient $\\nu$ for the 1-moment microphysics scheme (unitless)."
 
 [snow_flake_length_scale]
 value = 0.001
 type = "float"
-description = "1-moment microphysics snow particle length scale [m]"
+description = "Snow particle length scale for the 1-moment microphysics scheme (m)."
 
 [snow_mass_size_relation_coefficient_me]
 value = 2
 type = "float"
-description = "1-moment microphysics snow mass(radius) coefficient [-]"
+description = "Exponent $m_e$ in the mass-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_cross_section_size_relation_coefficient]
 value = 2
 type = "float"
-description = "1-moment microphysics snow cross section(radius) coefficient [-]"
+description = "Exponent in the cross section-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_terminal_velocity_size_relation_coefficient]
 value = 0.25
 type = "float"
-description = "1-moment microphysics snow terminal velocity(radius) coefficient [-]"
+description = "Exponent in the terminal velocity-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_mass_size_relation_coefficient_chim]
 value = 1
 type = "float"
-description = "1-moment microphysics snow mass(radius) coefficient [-]"
+description = "Coefficient $\\chi_m$ in the mass-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_mass_size_relation_coefficient_delm]
 value = 0
 type = "float"
-description = "1-moment microphysics snow mass(radius) coefficient [-]"
+description = "Coefficient $\\delta_m$ in the mass-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_cross_section_size_relation_coefficient_chia]
 value = 1
 type = "float"
-description = "1-moment microphysics snow cross section(radius) coefficient [-]"
+description = "Coefficient $\\chi_a$ in the cross section-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_cross_section_size_relation_coefficient_dela]
 value = 0
 type = "float"
-description = "1-moment microphysics snow drop cross section(radius) coefficient [-]"
+description = "Coefficient $\\delta_a$ in the cross section-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_terminal_velocity_size_relation_coefficient_chiv]
 value = 1
 type = "float"
-description = "1-moment microphysics snow terminal velocity(radius) coefficient [-]"
+description = "Coefficient $\\chi_v$ in the terminal velocity-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_terminal_velocity_size_relation_coefficient_delv]
 value = 0
 type = "float"
-description = "1-moment microphysics snow terminal velocity(radius) coefficient [-]"
+description = "Coefficient $\\delta_v$ in the terminal velocity-size relation for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_aspect_ratio]
 value = 0.15
 type = "float"
-description = "assumed aspect ratio in 1-moment microphysics for snow [-]"
+description = "Assumed aspect ratio for snow in the 1-moment microphysics scheme (unitless)."
 
 [snow_aspect_ratio_coefficient]
 value = 0.3333333333333333
 type = "float"
-description = "power law coeff. for terminal velocity dependence on snow aspect ratio from Chen et al 2022 [-]"
+description = "Power law coefficient for terminal velocity dependence on snow aspect ratio (unitless). Source: Chen et al. (2022)."
 
 [cloud_liquid_rain_collision_efficiency]
 value = 0.8
 type = "float"
-description = "1-moment microphysics cloud liquid rain collision efficiency [-]"
+description = "Collision efficiency between cloud liquid water and rain for the 1-moment scheme (unitless)."
 
 [cloud_liquid_snow_collision_efficiency]
 value = 0.1
 type = "float"
-description = "1-moment microphysics cloud liquid snow collision efficiency [-]"
+description = "Collision efficiency between cloud liquid water and snow for the 1-moment scheme (unitless)."
 
 [cloud_ice_rain_collision_efficiency]
 value = 1
 type = "float"
-description = "1-moment microphysics cloud ice rain collision efficiency [-]"
+description = "Collision efficiency between cloud ice and rain for the 1-moment scheme (unitless)."
 
 [cloud_ice_snow_collision_efficiency]
 value = 0.1
 type = "float"
-description = "1-moment microphysics cloud ice snow collision efficiency [-]"
+description = "Collision efficiency between cloud ice and snow for the 1-moment scheme (unitless)."
 
 [rain_snow_collision_efficiency]
 value = 1
 type = "float"
-description = "1-moment microphysics rain snow collision efficiency [-]"
+description = "Collision efficiency between rain and snow for the 1-moment scheme (unitless)."
 
 [prescribed_cloud_droplet_number_concentration]
 value = 1e8
 type = "float"
-description = "prescribed number concentration of cloud droplets [1/m3]"
+description = "Prescribed number concentration of cloud droplets (m⁻³)."
 
 [TC1980_autoconversion_coeff_D]
 value = 3268.0
 type = "float"
-description = "Tripoli and Cotton 1980 rain autoconversion coefficient [m^3b/s], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $D$ in the Tripoli and Cotton (1980) rain autoconversion parameterization ($m^{3b} s⁻¹$). Source: DOI: 10.1175/JAS3530.1."
 
 [TC1980_autoconversion_coeff_a]
-value = 2.33333333333333333333
+value = 2.3333333333333333
 type = "float"
-description = "default = 7/3, Tripoli and Cotton 1980 rain autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $a$ (default 7/3) in the Tripoli and Cotton (1980) rain autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [TC1980_autoconversion_coeff_b]
-value = -0.333333333333333333
+value = -0.3333333333333333
 type = "float"
-description = "default = -1/3, Tripoli and Cotton 1980 rain autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $b$ (default -1/3) in the Tripoli and Cotton (1980) rain autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [TC1980_autoconversion_coeff_r_0]
 value = 7e-6
 type = "float"
-description = "Tripoli and Cotton 1980 rain autoconversion threshold size [m], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Threshold size $r_0$ in the Tripoli and Cotton (1980) rain autoconversion parameterization (m). Source: DOI: 10.1175/JAS3530.1."
 
 [TC1980_autoconversion_coeff_me_liq]
 value = 3.0
 type = "float"
-description = "Tripoli and Cotton 1980 mass(size) [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Mass-size relation exponent $m_e$ in the Tripoli and Cotton (1980) scheme (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [TC1980_accretion_coeff_A]
-value =  4.7
+value = 4.7
 type = "float"
-description = "Tripoli and Cotton 1980 accretion coefficient [1/s], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $A$ in the Tripoli and Cotton (1980) accretion parameterization (s⁻¹). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_C]
-value = 3e34
+value = 3e+34
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [m^3(c+b-1) / s / kg^(b-1)], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $C$ in the Beheng (1994) autoconversion parameterization ($m^{3(c+b-1)} s⁻¹ kg^{-(b-1)}$). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_a]
 value = -1.7
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $a$ in the Beheng (1994) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_b]
 value = 4.7
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $b$ in the Beheng (1994) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_c]
 value = -3.3
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $c$ in the Beheng (1994) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_d_low]
 value = 3.9
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $d_{low}$ in the Beheng (1994) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_d_high]
 value = 9.9
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $d_{high}$ in the Beheng (1994) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_autoconversion_coeff_N_0]
-value = 2e8
+value = 2e+08
 type = "float"
-description = "Beheng 1994 autoconversion coefficient [1/m3], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $N_0$ in the Beheng (1994) autoconversion parameterization (m⁻³). Source: DOI: 10.1175/JAS3530.1."
 
 [B1994_accretion_coeff_A]
 value = 6.0
 type = "float"
-description = "Beheng 1994 accretion coefficient [1/s], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $A$ in the Beheng (1994) accretion parameterization (s⁻¹). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_autoconversion_coeff_A]
-value = 7.42e13
+value = 7.42e+13
 type = "float"
-description = "Khairoutdinov and Kogan 2000 autoconversion coefficient [m^3(b+c)/s/kg^c], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $A$ in the Khairoutdinov and Kogan (2000) autoconversion parameterization ($m^{3(b+c)} s⁻¹ kg^{-c}$). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_autoconversion_coeff_a]
 value = 2.47
 type = "float"
-description = "Khairoutdinov and Kogan 2000 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $a$ in the Khairoutdinov and Kogan (2000) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_autoconversion_coeff_b]
 value = -1.79
 type = "float"
-description = "Khairoutdinov and Kogan 2000 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $b$ in the Khairoutdinov and Kogan (2000) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_autoconversion_coeff_c]
 value = -1.47
 type = "float"
-description = "Khairoutdinov and Kogan 2000 autoconversion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $c$ in the Khairoutdinov and Kogan (2000) autoconversion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_accretion_coeff_A]
 value = 67.0
 type = "float"
-description = "Khairoutdinov and Kogan 2000 accretion coefficient [m^3b/kg^b/s], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $A$ in the Khairoutdinov and Kogan (2000) accretion parameterization ($m^{3b} kg^{-b} s⁻¹$). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_accretion_coeff_a]
 value = 1.15
 type = "float"
-description = "Khairoutdinov and Kogan 2000 accretion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $a$ in the Khairoutdinov and Kogan (2000) accretion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [KK2000_accretion_coeff_b]
 value = -1.3
 type = "float"
-description = "Khairoutdinov and Kogan 2000 accretion coefficient [-], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $b$ in the Khairoutdinov and Kogan (2000) accretion parameterization (unitless). Source: DOI: 10.1175/JAS3530.1."
 
 [LD2004_R_6C_coeff]
 value = 7.5
 type = "float"
-description = "Liu and Daum 2004 autoconversion coefficient [um^3/2 kg^1/6 / m^1/2], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient in the Liu and Daum (2004) autoconversion parameterization ($\\mu m^{3/2} kg^{1/6} m^{-1/2}$). Source: DOI: 10.1175/JAS3530.1."
 
 [LD2004_E_0_coeff]
-value = 1.08e10
+value = 1.08e+10
 type = "float"
-description = "Liu and Daum 2004 autoconversion coefficient [m^3/kg^2/s], see Table 1 in DOI: 10.1175/JAS3530.1"
+description = "Coefficient $E_0$ in the Liu and Daum (2004) autoconversion parameterization ($m^3 kg^{-2} s⁻¹$). Source: DOI: 10.1175/JAS3530.1."
 
 [Variable_time_scale_autoconversion_coeff_alpha]
 value = 1.0
 type = "float"
-description = "Power of number density in the function describing the autoconversion time scale. Unitless."
+description = "Exponent of number density in the function describing the autoconversion timescale (unitless)."
 
 [threshold_smooth_transition_steepness]
 value = 2.0
 type = "float"
+description = "A unitless steepness parameter for the smooth transition function used in threshold-based processes."
 
 [SB2006_collection_kernel_coeff_kcc]
-value = 4.44e9
+value = 4.44e+09
 type = "float"
-description = "Collection kernel constant [m^3 kg^-2 s^-1]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Cloud-cloud collection kernel constant $k_{cc}$ in the Seifert and Beheng (2006) scheme ($m^3 kg⁻² s⁻¹$). Source: DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_collection_kernel_coeff_kcr]
 value = 5.25
 type = "float"
-description = "Collection kernel constant [m^3 kg^-1 s^-1]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Cloud-rain collection kernel constant $k_{cr}$ in the Seifert and Beheng (2006) scheme ($m^3 kg⁻¹ s⁻¹$). Source: DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_collection_kernel_coeff_krr]
 value = 7.12
 type = "float"
-description = "Collection kernel constant [m^3 kg^-1 s^-1]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Rain-rain collection kernel constant $k_{rr}$ in the Seifert and Beheng (2006) scheme ($m^3 kg⁻¹ s⁻¹$). Source: DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_collection_kernel_coeff_kapparr]
 value = 60.7
 type = "float"
-description = "Collection kernel constant [kg^(-1/3)]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Collection kernel constant $\\kappa_{rr}$ in the Seifert and Beheng (2006) scheme ($kg^{-1/3}$). Source: DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_cloud_droplets_min_mass]
 value = 4.2e-15
 type = "float"
-description = "Minimum mass of cloud droplets [kg]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Minimum mass of cloud droplets in the Seifert and Beheng (2006) scheme (kg). Source: DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_min_mass]
 value = 2.6e-10
 type = "float"
-description = "Minimum mass of raindrops [kg]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Minimum mass of raindrops in the Seifert and Beheng (2006) scheme (kg). Source: DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_max_mass]
 value = 5e-6
 type = "float"
-description = "Maximum mass of raindrops [kg]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Maximum mass of raindrops in the Seifert and Beheng (2006) scheme (kg). Source: DOI: 10.1007/s00703-005-0112-4."
 
-[SB2006_cloud_gamma_distribution_parameter]
-value = 2
+[SB2006_cloud_gamma_distribution_coeff_nu]
+value = 1.0
 type = "float"
-description = "Gamma distibution parameter. Unitless. Default value from Seifert and Rasp, 2020. DOI: 10.1029/2020MS002301."
+description = "Gamma distribution coefficient $\\nu$ for clouds (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_cloud_gamma_distribution_coeff_mu]
 value = 1
 type = "float"
-description = "Gamma distibution coefficient. Unitless. Default value from Seifert and Rasp, 2020. DOI: 10.1029/2020MS002301."
+description = "Gamma distribution coefficient $\\mu$ for clouds (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_rain_distribution_coeff_nu]
 value = -0.66666666666667
 type = "float"
-description = "Gamma distibution coefficient. Unitless. Default value from Seifert and Rasp, 2020. DOI: 10.1029/2020MS002301."
+description = "Gamma distribution coefficient $\\nu$ for rain (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_rain_distribution_coeff_mu]
 value = 0.33333333333333
 type = "float"
-description = "Gamma distibution coefficient. Unitless. Default value from Seifert and Rasp, 2020. DOI: 10.1029/2020MS002301."
+description = "Gamma distribution coefficient $\\mu$ for rain (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_reference_air_density]
 value = 1.225
 type = "float"
-description = "Air density at surface conditions [kg/m^3]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Reference air density at surface conditions (kg m⁻³). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_autoconversion_correcting_function_coeff_A]
 value = 400.0
 type = "float"
-description = "Constant in the universal function that corrects the autoconversion rate. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $A$ in the universal function correcting the autoconversion rate (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_autoconversion_correcting_function_coeff_a]
 value = 0.7
 type = "float"
-description = "Constant in the universal function that corrects the autoconversion rate. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $a$ in the universal function correcting the autoconversion rate (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_autoconversion_correcting_function_coeff_b]
 value = 3
 type = "float"
-description = "Constant in the universal function that corrects the autoconversion rate. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $b$ in the universal function correcting the autoconversion rate (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_accretion_correcting_function_coeff_tau0]
 value = 5e-5
 type = "float"
-description = "Constant in the universal function that corrects the accretion rate. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $\tau_0$ in the universal function correcting the accretion rate (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_accretion_correcting_function_coeff_c]
 value = 4
 type = "float"
-description = "Constant in the universal function that corrects the accretion rate. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $c$ in the universal function correcting the accretion rate (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_self-collection_coeff_d]
 value = -5
 type = "float"
-description = "Constant in raindrops self-collection rate equation. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $d$ in the raindrops self-collection rate equation (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
-[SB2006_raindrops_equlibrium_mean_diameter]
+[SB2006_raindrops_equilibrium_mean_diameter]
 value = 9e-4
 type = "float"
-description = "Equilibrium mean diameter of raindrops for computing the breakup rate [m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Equilibrium mean diameter of raindrops for computing the breakup rate (m). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_breakup_mean_diameter_threshold]
 value = 3.5e-4
 type = "float"
-description = "Threshold of raindrops mean diameter for breakup [m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Threshold of raindrops mean diameter for breakup (m). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_breakup_coeff_kbr]
 value = 1000
 type = "float"
-description = "Parameter of the raindrops breakup rate equation [1/m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $k_{br}$ in the raindrops breakup rate equation (m⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_breakup_coeff_kappabr]
 value = 2300
 type = "float"
-description = "Parameter of the raindrops breakup rate equation [1/m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $\\kappa_{br}$ in the raindrops breakup rate equation (m⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_terminal_velocity_coeff_aR]
 value = 9.65
 type = "float"
-description = "Parameter of the raindrops terminal velocity equation [m/s]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $a_R$ in the raindrops terminal velocity equation (m s⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_terminal_velocity_coeff_bR]
 value = 10.3
 type = "float"
-description = "Parameter of the raindrops terminal velocity equation [m/s]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $b_R$ in the raindrops terminal velocity equation (m s⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_terminal_velocity_coeff_cR]
 value = 600
 type = "float"
-description = "Parameter of the raindrops terminal velocity equation [1/m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $c_R$ in the raindrops terminal velocity equation (m⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_ventilation_factor_coeff_av]
 value = 0.78
 type = "float"
-description = "Constant in ventilation factor equation for computing the evaporation rate of rain. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $a_v$ in the ventilation factor equation for rain evaporation (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_ventilation_factor_coeff_bv]
 value = 0.308
 type = "float"
-description = "Constant in ventilation factor equation for computing the evaporation rate of rain. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $b_v$ in the ventilation factor equation for rain evaporation (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
-[SB2006_rain_evaportation_coeff_alpha]
+[SB2006_rain_evaporation_coeff_alpha]
 value = 159
 type = "float"
-description = "Constant in fallspeed relation for computing the evaporation rate of rain. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $\\alpha$ in the fallspeed relation for rain evaporation (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
-[SB2006_rain_evaportation_coeff_beta]
+[SB2006_rain_evaporation_coeff_beta]
 value = 0.266
 type = "float"
-description = "Constant in fallspeed relation for computing the evaporation rate of rain. Unitless. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Coefficient $\\beta$ in the fallspeed relation for rain evaporation (unitless). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_size_distribution_coeff_N0_min]
 value = 2.5e5
 type = "float"
-description = "Minimum of raindrops size distribution parameter N0 [m^(-4)]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Minimum value of the raindrops size distribution parameter $N_0$ (m⁻⁴). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_size_distribution_coeff_N0_max]
 value = 2e7
 type = "float"
-description = "Maximum of raindrops size distribution parameter N0 [m^(-4)]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Maximum value of the raindrops size distribution parameter $N_0$ (m⁻⁴). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_size_distribution_coeff_lambda_min]
 value = 1e3
 type = "float"
-description = "Minimum of raindrops size distribution parameter λ [1/m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Minimum value of the raindrops size distribution parameter $\\lambda$ (m⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [SB2006_raindrops_size_distribution_coeff_lambda_max]
 value = 1e4
 type = "float"
-description = "Maximum of raindrops size distribution parameter λ [1/m]. From Seifert and Beheng, 2006. DOI: 10.1007/s00703-005-0112-4."
+description = "Maximum value of the raindrops size distribution parameter $\\lambda$ (m⁻¹). Source: Seifert and Beheng (2006), DOI: 10.1007/s00703-005-0112-4."
 
 [Horn2012_number_concentration_adjustment_timescale]
 value = 100
 type = "float"
-description = "2-moment number concentration adjustment timescale [s]. From Horn, 2012. DOI: 10.5194/gmd-5-345-2012."
+description = "Timescale for 2-moment number concentration adjustment (s). Source: Horn (2012), DOI: 10.5194/gmd-5-345-2012."
 
 [Chen2022_table_B1_q_coeff]
 value = 0.115231
 type = "float"
-description = "q coefficinet for raindrop terminal velocity parameterization [-]. See Table B1 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficient $q$ for raindrop terminal velocity parameterization (unitless). Source: Table B1 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B1_ai]
 value = [0.044612, -0.263166, 4.7178]
 type = "float"
-description = "ai coefficients for raindrop terminal velocity parameterization [mm^-bi]. See Table B1 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $a_i$ for raindrop terminal velocity parameterization ($mm^{-b_i}$). Source: Table B1 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B1_a3_pow_coeff]
 value = -0.47335
 type = "float"
-description = "a3 coefficinet for raindrop terminal velocity parameterization [-]. See Table B1 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Power coefficient for $a_3$ in raindrop terminal velocity parameterization (unitless). Source: Table B1 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B1_bi]
 value = [2.2955, 2.2955, 1.1451]
 type = "float"
-description = "bi coefficients for raindrop terminal velocity parameterization [-]. See Table B1 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $b_i$ for raindrop terminal velocity parameterization (unitless). Source: Table B1 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B1_b_rho_coeff]
 value = 0.038465
 type = "float"
-description = "b density coefficinet for raindrop terminal velocity parameterization [m3/kg]. See Table B1 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Density coefficient $b_{\\rho}$ for raindrop terminal velocity parameterization (m³ kg⁻¹). Source: Table B1 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B1_ci]
 value = [0.0, 0.184325, 0.184325]
 type = "float"
-description = "ci coefficients for raindrop terminal velocity parameterization [1/mm]. See Table B1 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $c_i$ for raindrop terminal velocity parameterization (mm⁻¹). Source: Table B1 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B3_As]
 value = [-0.263503, 0.00174079, 0.0378769]
 type = "float"
-description = "As coefficients for ice terminal velocity parameterization - See Table B3 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $A_s$ for ice terminal velocity parameterization. Source: Table B3 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B3_Bs]
 value = [0.575231, 0.0909307, 0.515579]
 type = "float"
-description = "Bs coefficients for ice terminal velocity parameterization - See Table B3 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $B_s$ for ice terminal velocity parameterization. Source: Table B3 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B3_Cs]
 value = [-0.345387, 0.177362, -0.000427794, 0.00419647]
 type = "float"
-description = "Cs coefficients for ice terminal velocity parameterization - See Table B3 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $C_s$ for ice terminal velocity parameterization. Source: Table B3 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B3_Es]
 value = [-0.156593, 0.0189334, 0.1377817]
 type = "float"
-description = "Es coefficients for ice terminal velocity parameterization - See Table B3 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $E_s$ for ice terminal velocity parameterization. Source: Table B3 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B3_Fs]
 value = [-3.35641, 0.0156199, 0.765337]
 type = "float"
-description = "Fs coefficients for ice terminal velocity parameterization - See Table B3 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $F_s$ for ice terminal velocity parameterization. Source: Table B3 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B3_Gs]
 value = [-0.0309715, 1.55054, 0.518349]
 type = "float"
-description = "Gs coefficients for ice terminal velocity parameterization - See Table B3 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $G_s$ for ice terminal velocity parameterization. Source: Table B3 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_Al]
-value = [-0.475897, -0.00231270, 1.12293]
+value = [-0.475897, -0.0023127, 1.12293]
 type = "float"
-description = "Al coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $A_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_Bl]
 value = [-2.56289, -0.00513504, 0.608459]
 type = "float"
-description = "Bl coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $B_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_Cl]
 value = [-0.756064, 0.935922, -1.70952]
 type = "float"
-description = "Cl coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $C_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_El]
 value = [0.00639847, 0.00906454, -0.108232]
 type = "float"
-description = "El coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $E_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_Fl]
-value = [0.515453, -0.0725042, -1.86810e19]
+value = [0.515453, -0.0725042, -1.8681e+19]
 type = "float"
-description = "Fl coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $F_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_Gl]
 value = [2.65236, 0.00158269, 259.935]
 type = "float"
-description = "Gl coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $G_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_table_B5_Hl]
-value = [-0.346044, -7.17829e-11, -1.24394e20]
+value = [-0.346044, -7.17829e-11, -1.24394e+20]
 type = "float"
-description = "Hl coefficients for ice terminal velocity parameterization - See Table B5 in Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171"
+description = "Coefficients $H_l$ for ice terminal velocity parameterization. Source: Table B5 in Chen et al. (2022), DOI: 10.1016/j.atmosres.2022.106171."
 
 [Chen2022_ice_cutoff]
 value = 0.000625
 type = "float"
-description = "Chen2022 parametrization cut off for diameter between small and large ice particles [m]"
+description = "Cutoff diameter between small and large ice particles in the Chen et al. (2022) parameterization (m)."
 
-# Microphysics - ice deposition on dust
+# Microphysics - Ice Deposition on Dust (Mohler et al., 2006)
 
 [Mohler2006_maximum_allowed_Si]
 value = 1.35
 type = "float"
-description = "Maximum allowed supersaturation over ice Si_max [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Maximum allowed supersaturation over ice, $S_{i,max}$ (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_threshold_T]
 value = 220
 type = "float"
-description = "Threshold temperature separating two deposition regimes [K]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Threshold temperature, $T_{thr}$, separating two deposition regimes (K). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_S0_warm_ArizonaTestDust]
 value = 1.03
 type = "float"
-description = "S0 for temperatures > T_thr for Arizona Test Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Onset saturation ratio $S_0$ for temperatures > $T_{thr}$ for Arizona Test Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_S0_cold_ArizonaTestDust]
 value = 1.07
 type = "float"
-description = "S0 for temperatures < T_thr for Arizona Test Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Onset saturation ratio $S_0$ for temperatures < $T_{thr}$ for Arizona Test Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_a_warm_ArizonaTestDust]
 value = 4.7
 type = "float"
-description = "a for temperatures > T_thr for Arizona Test Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Coefficient 'a' for temperatures > $T_{thr}$ for Arizona Test Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_a_cold_ArizonaTestDust]
 value = 9.2
 type = "float"
-description = "a for temperatures < T_thr for Arizona Test Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Coefficient 'a' for temperatures < $T_{thr}$ for Arizona Test Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_S0_warm_DesertDust]
 value = 1.17
 type = "float"
-description = "S0 for temperatures > T_thr for Desert Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Onset saturation ratio $S_0$ for temperatures > $T_{thr}$ for Desert Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_S0_cold_DesertDust]
 value = 1.03
 type = "float"
-description = "S0 for temperatures < T_thr for Desert Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Onset saturation ratio $S_0$ for temperatures < $T_{thr}$ for Desert Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_a_warm_DesertDust]
 value = 0.43
 type = "float"
-description = "a for temperatures > T_thr for Desert Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Coefficient 'a' for temperatures > $T_{thr}$ for Desert Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
 [Mohler2006_a_cold_DesertDust]
 value = 2.35
 type = "float"
-description = "a for temperatures < T_thr for Desert Dust [-]. From Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006."
+description = "Coefficient 'a' for temperatures < $T_{thr}$ for Desert Dust (unitless). Source: Mohler et al. (2006), DOI: 10.5194/acp-6-3007-2006."
 
-# Microphysics - water activity based ice deposition nucleation
+# Microphysics - Water-Activity-Based Deposition Nucleation (ABDINM)
 
 [J_ABDINM_m_Dust]
 value = 13.2251
 type = "float"
-description = "Arbitrary coefficient, m, for calculating deposition nucleation J_het of any dust [-]."
+description = "Default empirical coefficient 'm' for the water-activity-based deposition nucleation rate ($J_{het}$) parameterization for dust (unitless)."
 
 [J_ABDINM_c_Dust]
 value = 0.7716
 type = "float"
-description = "Arbitrary coefficient, c, for calculating deposition nucleation J_het of any dust [-]."
+description = "Default empirical coefficient 'c' for the water-activity-based deposition nucleation rate ($J_{het}$) parameterization for dust (unitless)."
 
 [J_ABDINM_m_Illite]
 value = 13.2251
 type = "float"
-description = "Arbitrary coefficient, m, for calculating deposition nucleation J_het of Illite [-]."
+description = "Empirical coefficient 'm' for the deposition nucleation rate ($J_{het}$) of Illite (unitless)."
 
 [J_ABDINM_c_Illite]
 value = 0.7716
 type = "float"
-description = "Arbitrary coefficient, c, for calculating deposition nucleation J_het of Illite [-]."
+description = "Empirical coefficient 'c' for the deposition nucleation rate ($J_{het}$) of Illite (unitless)."
 
 [J_ABDINM_m_SaharanDust]
 value = 13.2251
 type = "float"
-description = "Arbitrary coefficient, m, for calculating deposition nucleation J_het of Saharan Dust [-]."
+description = "Empirical coefficient 'm' for the deposition nucleation rate ($J_{het}$) of Saharan Dust (unitless)."
 
 [J_ABDINM_c_SaharanDust]
 value = 0.7716
 type = "float"
-description = "Arbitrary coefficient, c, for calculating deposition nucleation J_het of Saharan Dust [-]."
+description = "Empirical coefficient 'c' for the deposition nucleation rate ($J_{het}$) of Saharan Dust (unitless)."
 
 [J_ABDINM_m_AsianDust]
 value = 13.2251
 type = "float"
-description = "Arbitrary coefficient, m, for calculating deposition nucleation J_het of Asian Dust [-]."
+description = "Empirical coefficient 'm' for the deposition nucleation rate ($J_{het}$) of Asian Dust (unitless)."
 
 [J_ABDINM_c_AsianDust]
 value = 0.7716
 type = "float"
-description = "Arbitrary coefficient, c, for calculating deposition nucleation J_het of Asian Dust [-]."
+description = "Empirical coefficient 'c' for the deposition nucleation rate ($J_{het}$) of Asian Dust (unitless)."
 
 [J_ABDINM_m_ArizonaTestDust]
 value = 13.2251
 type = "float"
-description = "Arbitrary coefficient, m, for calculating deposition nucleation J_het of Arizona Test Dust [-]."
+description = "Empirical coefficient 'm' for the deposition nucleation rate ($J_{het}$) of Arizona Test Dust (unitless)."
 
 [J_ABDINM_c_ArizonaTestDust]
 value = 0.7716
 type = "float"
-description = "Arbitrary coefficient, c, for calculating deposition nucleation J_het of Arizona Test Dust [-]."
+description = "Empirical coefficient 'c' for the deposition nucleation rate ($J_{het}$) of Arizona Test Dust (unitless)."
 
 [Alpert2022_J_deposition_m_Feldspar]
 value = 13.2251
 type = "float"
-description = "Coefficient, m, for calculating deposition nucleation J_het of Feldspar [-]. From Alpert et al 2022. DOI: 10.1039/D1EA00077B."
+description = "Coefficient 'm' for deposition nucleation rate $J_{het}$ of Feldspar (unitless). Source: Alpert et al. (2022), DOI: 10.1039/D1EA00077B."
 
 [Alpert2022_J_deposition_c_Feldspar]
 value = 0.7716
 type = "float"
-description = "Coefficient, c, for calculating deposition nucleation J_het of Feldspar [-]. From Alpert et al 2022. DOI: 10.1039/D1EA00077B."
+description = "Coefficient 'c' for deposition nucleation rate $J_{het}$ of Feldspar (unitless). Source: Alpert et al. (2022), DOI: 10.1039/D1EA00077B."
 
 [Alpert2022_J_deposition_m_Ferrihydrite]
 value = 12.3525
 type = "float"
-description = "Coefficient, m, for calculating deposition nucleation J_het of Ferrihydrite [-]. From Alpert et al 2022. DOI: 10.1039/D1EA00077B."
+description = "Coefficient 'm' for deposition nucleation rate $J_{het}$ of Ferrihydrite (unitless). Source: Alpert et al. (2022), DOI: 10.1039/D1EA00077B."
 
 [Alpert2022_J_deposition_c_Ferrihydrite]
 value = 0.0516
 type = "float"
-description = "Coefficient, c, for calculating deposition nucleation J_het of Ferrihydrite [-]. From Alpert et al 2022. DOI: 10.1039/D1EA00077B."
+description = "Coefficient 'c' for deposition nucleation rate $J_{het}$ of Ferrihydrite (unitless). Source: Alpert et al. (2022), DOI: 10.1039/D1EA00077B."
 
 [China2017_J_deposition_m_Kaolinite]
 value = 27.551
 type = "float"
-description = "Coefficient, m, for calculating deposition nucleation J_het of Kaolinite [-]. From China et al 2017. DOI: 10.1002/2016JD025817."
+description = "Coefficient 'm' for deposition nucleation rate $J_{het}$ of Kaolinite (unitless). Source: China et al. (2017), DOI: 10.1002/2016JD025817."
 
 [China2017_J_deposition_c_Kaolinite]
 value = -2.2209
 type = "float"
-description = "Coefficient, c, for calculating deposition nucleation J_het of Kaolinite [-]. From China et al 2017. DOI: 10.1002/2016JD025817."
+description = "Coefficient 'c' for deposition nucleation rate $J_{het}$ of Kaolinite (unitless). Source: China et al. (2017), DOI: 10.1002/2016JD025817."
 
-# Microphysics - water activity based immersion freezing/nucleation
+# Microphysics - Water-Activity-Based Immersion Freezing (ABIFM)
 
 [J_ABIFM_m_Dust]
 value = 22.62
 type = "float"
-description = "Arbitrary coefficient, m, for calculating immersion freezing J_het of any dust [-]."
+description = "Default empirical coefficient 'm' for the water-activity-based immersion freezing rate ($J_{het}$) parameterization for dust (unitless)."
 
 [J_ABIFM_c_Dust]
 value = -1.35
 type = "float"
-description = "Arbitrary coefficient, c, for calculating immersion freezing J_het of any dust [-]."
+description = "Default empirical coefficient 'c' for the water-activity-based immersion freezing rate ($J_{het}$) parameterization for dust (unitless)."
 
 [J_ABIFM_m_ArizonaTestDust]
 value = 22.62
 type = "float"
-description = "Arbitrary coefficient, m, for calculating immersion freezing J_het of Arizona Test Dust [-]."
+description = "Empirical coefficient 'm' for the immersion freezing rate ($J_{het}$) of Arizona Test Dust (unitless)."
 
 [J_ABIFM_c_ArizonaTestDust]
 value = -1.35
 type = "float"
-description = "Arbitrary coefficient, c, for calculating immersion freezing J_het of Arizona Test Dust [-]."
+description = "Empirical coefficient 'c' for the immersion freezing rate ($J_{het}$) of Arizona Test Dust (unitless)."
 
 [J_ABIFM_m_SaharanDust]
 value = 22.62
 type = "float"
-description = "Arbitrary coefficient, m, for calculating immersion freezing J_het of Saharan Dust [-]."
+description = "Empirical coefficient 'm' for the immersion freezing rate ($J_{het}$) of Saharan Dust (unitless)."
 
 [J_ABIFM_c_SaharanDust]
 value = -1.35
 type = "float"
-description = "Arbitrary coefficient, c, for calculating immersion freezing J_het of Saharan Dust [-]."
+description = "Empirical coefficient 'c' for the immersion freezing rate ($J_{het}$) of Saharan Dust (unitless)."
 
 [J_ABIFM_m_AsianDust]
 value = 22.62
 type = "float"
-description = "Arbitrary coefficient, m, for calculating immersion freezing J_het of Asian Dust [-]."
+description = "Empirical coefficient 'm' for the immersion freezing rate ($J_{het}$) of Asian Dust (unitless)."
 
 [J_ABIFM_c_AsianDust]
 value = -1.35
 type = "float"
-description = "Arbitrary coefficient, c, for calculating immersion freezing J_het of Asian Dust [-]."
+description = "Empirical coefficient 'c' for the immersion freezing rate ($J_{het}$) of Asian Dust (unitless)."
 
 [J_ABIFM_m_MiddleEasternDust]
 value = 22.62
 type = "float"
-description = "Arbitrary coefficient, m, for calculating immersion freezing J_het of Middle Eastern Dust [-]."
+description = "Empirical coefficient 'm' for the immersion freezing rate ($J_{het}$) of Middle Eastern Dust (unitless)."
 
 [J_ABIFM_c_MiddleEasternDust]
 value = -1.35
 type = "float"
-description = "Arbitrary coefficient, c, for calculating immersion freezing J_het of Middle Eastern Dust [-]."
+description = "Empirical coefficient 'c' for the immersion freezing rate ($J_{het}$) of Middle Eastern Dust (unitless)."
 
 [AlpertKnopf2016_J_ABIFM_m_DesertDust]
 value = 22.62
 type = "float"
-description = "Coefficient, m, for calculating immersion freezing J_het of Desert Dust [-]. From Alpert and Knopf 2016. DOI: 10.5194/acp-16-2083-2016."
+description = "Coefficient 'm' for immersion freezing rate $J_{het}$ of Desert Dust (unitless). Source: Alpert and Knopf (2016), DOI: 10.5194/acp-16-2083-2016."
 
 [AlpertKnopf2016_J_ABIFM_c_DesertDust]
 value = -1.35
 type = "float"
-description = "Coefficient, c, for calculating immersion freezing J_het of Desert Dust [-]. From Alpert and Knopf 2016. DOI: 10.5194/acp-16-2083-2016."
+description = "Coefficient 'c' for immersion freezing rate $J_{het}$ of Desert Dust (unitless). Source: Alpert and Knopf (2016), DOI: 10.5194/acp-16-2083-2016."
 
 [KnopfAlpert2013_J_ABIFM_m_Kaolinite]
 value = 54.58834
 type = "float"
-description = "Coefficient, m, for calculating immersion freezing J_het of Kaolinite [-]. From Knopf and Alpert 2013. DOI: 10.1039/C3FD00035D."
+description = "Coefficient 'm' for immersion freezing rate $J_{het}$ of Kaolinite (unitless). Source: Knopf and Alpert (2013), DOI: 10.1039/C3FD00035D."
 
 [KnopfAlpert2013_J_ABIFM_c_Kaolinite]
 value = -10.54758
 type = "float"
-description = "Coefficient, c, for calculating immersion freezing J_het of Kaolinite [-]. From Knopf and Alpert 2013. DOI: 10.1039/C3FD00035D."
+description = "Coefficient 'c' for immersion freezing rate $J_{het}$ of Kaolinite (unitless). Source: Knopf and Alpert (2013), DOI: 10.1039/C3FD00035D."
 
 [KnopfAlpert2013_J_ABIFM_m_Illite]
 value = 54.48075
 type = "float"
-description = "Coefficient, m, for calculating immersion freezing J_het of Illite [-]. From Knopf and Alpert 2013. DOI: 10.1039/C3FD00035D."
+description = "Coefficient 'm' for immersion freezing rate $J_{het}$ of Illite (unitless). Source: Knopf and Alpert (2013), DOI: 10.1039/C3FD00035D."
 
 [KnopfAlpert2013_J_ABIFM_c_Illite]
 value = -10.66873
 type = "float"
-description = "Coefficient, c, for calculating immersion freezing J_het of Illite [-]. From Knopf and Alpert 2013. DOI: 10.1039/C3FD00035D."
+description = "Coefficient 'c' for immersion freezing rate $J_{het}$ of Illite (unitless). Source: Knopf and Alpert (2013), DOI: 10.1039/C3FD00035D."
 
-# Microphysics - P3 ice nucleation paramerizations
+# Microphysics - P3 Scheme Ice Nucleation
 
 [Thompson2004_c1_Cooper]
-value = 0.005
+value = 5e-3
 type = "float"
-description = "Coefficient, c1, for calculating P3 deposition nucleation [-]. From Thompson et al 2004. DOI: 10.1175/1520-0493(2004)132<0519:EFOWPU>2.0.CO;2."
+description = "Coefficient $c_1$ for calculating P3 deposition nucleation (unitless). Source: Thompson et al. (2004), DOI: 10.1175/1520-0493(2004)132<0519:EFOWPU>2.0.CO;2."
 
 [Thompson2004_c2_Cooper]
 value = 0.304
 type = "float"
-description = "Coefficient, c2, for calculating P3 deposition nucleation [-]. From Thompson et al 2004. DOI: 10.1175/1520-0493(2004)132<0519:EFOWPU>2.0.CO;2."
+description = "Coefficient $c_2$ for calculating P3 deposition nucleation (unitless). Source: Thompson et al. (2004), DOI: 10.1175/1520-0493(2004)132<0519:EFOWPU>2.0.CO;2."
 
 [BarklieGokhale1959_a_parameter]
 value = 0.65
 type = "float"
-description = "Mean of parameter a for determining P3 heterogeneous freezing [°C^-1]. From Barklie & Gokhale 1959. No DOI. See Pruppacher & Klett 1997 pg 350."
+description = "Mean of parameter 'a' for determining P3 heterogeneous freezing ($°C⁻¹$). Source: Barklie & Gokhale (1959), see Pruppacher & Klett (1997), p. 350."
 
 [BarklieGokhale1959_B_parameter]
 value = 2e-4
 type = "float"
-description = "Parameter, B, for rain water. Used to determine P3 heterogeneous freezing. [cm^-3 s^-1]. From Barklie & Gokhale 1959. No DOI. See Pruppacher & Klett 1997 pg 350."
+description = "Parameter 'B' for rainwater, used to determine P3 heterogeneous freezing (cm⁻³ s⁻¹). Source: Barklie & Gokhale (1959), see Pruppacher & Klett (1997), p. 350."
 
-# Microphysics - P3 particle properties parameterizations: mass, area, size distribution, density
+# Microphysics - P3 Scheme Particle Properties
 
 [BF1995_mass_exponent_beta]
 value = 1.9
 type = "float"
-description = "Exponent in power law for mass grown by vapor diffusion and aggregation from Brown and Francis 1995--used in P3 Scheme (Morrison and Milbrandt 2015) [-]."
+description = "Exponent $\\beta_{va}$ in the power law for mass from vapor diffusion/aggregation in the P3 scheme (unitless). Source: Brown and Francis (1995); Morrison and Milbrandt (2015)."
 
 [BF1995_mass_coeff_alpha]
 value = 7.38e-11
 type = "float"
-description = "Coefficient in power law for mass grown by vapor diffusion and aggregation from Brown and Francis 1995--used in P3 Scheme (Morrison and Milbrandt 2015) [g/μmβ_va]. To adjust units into kg and m, see the P3 Scheme documentation."
+description = "Coefficient $\\alpha_{va}$ in the power law for mass from vapor diffusion/aggregation in the P3 scheme ($g \\mu m^{-\\beta_{va}}$). See P3 scheme documentation to adjust units. Source: Brown and Francis (1995); Morrison and Milbrandt (2015)."
 
 [M1996_area_exponent_sigma]
 value = 1.88
 type = "float"
-description = "Exponent in power law for the area of ice side plane, column, bullet, and planar polycrystal aggregates in Mitchell 1996--used in P3 Scheme (Morrison and Milbrandt 2015) [-]."
+description = "Exponent $\\sigma$ in the power law for the projected area of various ice habits in the P3 scheme (unitless). Source: Mitchell (1996); Morrison and Milbrandt (2015)."
 
 [M1996_area_coeff_gamma]
 value = 0.2285
 type = "float"
-description = "Coefficient in power law for the area of ice side plane, column, bullet, and planar polycrystal aggregates in Mitchell 1996--used in P3 Scheme (Morrison and Milbrandt 2015) [μm^(2-σ_M1996)]. To adjust units into m and m2, see the P3 Scheme documentation."
+description = "Coefficient $\\gamma$ in the power law for the projected area of various ice habits in the P3 scheme ($\\mu m^{2-\\sigma}$). See P3 scheme documentation to adjust units. Source: Mitchell (1996); Morrison and Milbrandt (2015)."
 
 [Heymsfield_mu_coeff1]
-value = 0.00191
+value = 1.91e-3
 type = "float"
-description = "Coefficient for shape parameter mu for ice in P3 scheme. See eq 3 in Morrison and Milbrandt 2015. Units: [m^0.8]"
+description = "Coefficient for shape parameter $\\mu$ for ice in the P3 scheme ($m^{0.8}$). Source: Eq. (3) in Morrison and Milbrandt (2015)."
 
 [Heymsfield_mu_coeff2]
 value = 0.8
 type = "float"
-description = "Coefficient for shape parameter mu for ice in P3 scheme. See eq 3 in Morrison and Milbrandt 2015. Units: [-]"
+description = "Coefficient for shape parameter $\\mu$ for ice in the P3 scheme (unitless). Source: Eq. (3) in Morrison and Milbrandt (2015)."
 
 [Heymsfield_mu_coeff3]
 value = 2
 type = "float"
-description = "Coefficient for shape parameter mu for ice in P3 scheme. See eq 3 in Morrison and Milbrandt 2015. Units: [-]"
+description = "Coefficient for shape parameter $\\mu$ for ice in the P3 scheme (unitless). Source: Eq. (3) in Morrison and Milbrandt (2015)."
 
 [Heymsfield_mu_cutoff]
 value = 6
 type = "float"
-description = "Limiter for shape parameter mu for ice in P3 scheme. See eq 3 in Morrison and Milbrandt 2015. Units: [-]"
+description = "Limiter for shape parameter $\\mu$ for ice in the P3 scheme (unitless). Source: Eq. (3) in Morrison and Milbrandt (2015)."
 
 [P3_constant_slope_parameterization_value]
 value = 3.0
 type = "float"
-description = "Value of μ for constant slope parameterization in P3 scheme. Units: [-]"
+description = "Value of $\\mu$ for the constant slope parameterization in the P3 scheme (unitless)."
 
 [CL1993_local_rime_density_constant_coeff]
 value = 51
 type = "float"
-description = "Constant coefficient for local rime density in P3 scheme. Units: [kg / m³]. See Eq. (17) in Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2"
+description = "Constant coefficient for local rime density in the P3 scheme (kg m⁻³). Source: Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2."
 
 [CL1993_local_rime_density_linear_coeff]
 value = 114
 type = "float"
-description = "Linear coefficient for local rime density in P3 scheme. Units: [kg / m³ / (m² / s / °C)]. See Eq. (17) in Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2"
+description = "Linear coefficient for local rime density in the P3 scheme (kg m⁻³ (m² s⁻¹ °C⁻¹)⁻¹). Source: Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2."
 
 [CL1993_local_rime_density_quadratic_coeff]
 value = -5.5
 type = "float"
-description = "Quadratic coefficient for local rime density in P3 scheme. Units: [kg / m³ / (m² / s / °C)²]. See Eq. (17) in Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2"
+description = "Quadratic coefficient for local rime density in the P3 scheme (kg m⁻³ (m² s⁻¹ °C⁻¹)⁻²). Source: Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2."
 
 [P3_wet_growth_timescale]
 value = 100
 type = "float"
-description = "Timescale for densification due to wet growth in P3 scheme. Units: [s]."
+description = "Timescale for densification due to wet growth in the P3 scheme (s)."
 
-# Microphysics - temperature dependant, aerosol independant immerson freezing
+# Microphysics - Temperature-Dependent Immersion Freezing
 
 [Frostenberg2023_standard_deviation]
 value = 1.37
 type = "float"
-description = "Standard deviation for the ice nucleating particles concentration [-]. Eq (1) in Frostenberg et al 2023 doi: 10.5194/acp-23-10883-2023"
+description = "Standard deviation of the log of the ice-nucleating particle concentration (unitless). Source: Eq. (1) in Frostenberg et al. (2023), DOI: 10.5194/acp-23-10883-2023."
 
 [Frostenberg2023_a_coefficient]
 value = 1
 type = "float"
-description = "Coefficient a for the ice nucleating particles concentration [m^3]. Eq (1) in Frostenberg et al 2023 doi: 10.5194/acp-23-10883-2023"
+description = "Coefficient 'a' for the ice-nucleating particle concentration (m³). Source: Eq. (1) in Frostenberg et al. (2023), DOI: 10.5194/acp-23-10883-2023."
 
 [Frostenberg2023_b_coefficient]
 value = 1
 type = "float"
-description = "Coefficient b for the ice nucleating particles concentration [1/C]. Eq (1) in Frostenberg et al 2023 doi: 10.5194/acp-23-10883-2023"
+description = "Coefficient 'b' for the ice-nucleating particle concentration (°C⁻¹). Source: Eq. (1) in Frostenberg et al. (2023), DOI: 10.5194/acp-23-10883-2023."
 
-# Microphysics - water activity based homogeneous freezing/nucleation
+# Microphysics - Water-Activity-Based Homogeneous Freezing
 
 [Koop2000_min_delta_aw]
 value = 0.26
 type = "float"
-description = "Minimum valid Delta_a_w for J_hom parameterized by Koop 2000 [-]. From Koop 2000. DOI: 10.1038/35020537."
+description = "Minimum valid water activity difference $\\Delta a_w$ for the Koop (2000) homogeneous nucleation parameterization (unitless). Source: DOI: 10.1038/35020537."
 
 [Koop2000_max_delta_aw]
 value = 0.34
 type = "float"
-description = "Maximum valid Delta_a_w for J_hom parameterized by Koop 2000 [-]. From Koop 2000. DOI: 10.1038/35020537."
+description = "Maximum valid water activity difference $\\Delta a_w$ for the Koop (2000) homogeneous nucleation parameterization (unitless). Source: DOI: 10.1038/35020537."
 
 [Koop2000_J_hom_coeff1]
 value = -906.7
 type = "float"
-description = "Coefficient for calculating J_hom parameterized by Koop 2000 [-]. From Koop 2000. DOI: 10.1038/35020537."
+description = "Coefficient for calculating the homogeneous nucleation rate $J_{hom}$ (unitless). Source: Koop et al. (2000), DOI: 10.1038/35020537."
 
 [Koop2000_J_hom_coeff2]
 value = 8502
 type = "float"
-description = "Coefficient for calculating J_hom parameterized by Koop 2000 [-]. From Koop 2000. DOI: 10.1038/35020537."
+description = "Coefficient for calculating the homogeneous nucleation rate $J_{hom}$ (unitless). Source: Koop et al. (2000), DOI: 10.1038/35020537."
 
 [Koop2000_J_hom_coeff3]
 value = 26924
 type = "float"
-description = "Coefficient for calculating J_hom parameterized by Koop 2000 [-]. From Koop 2000. DOI: 10.1038/35020537."
+description = "Coefficient for calculating the homogeneous nucleation rate $J_{hom}$ (unitless). Source: Koop et al. (2000), DOI: 10.1038/35020537."
 
 [Koop2000_J_hom_coeff4]
 value = 29180
 type = "float"
-description = "Coefficient for calculating J_hom parameterized by Koop 2000 [-]. From Koop 2000. DOI: 10.1038/35020537."
+description = "Coefficient for calculating the homogeneous nucleation rate $J_{hom}$ (unitless). Source: Koop et al. (2000), DOI: 10.1038/35020537."
 
 [Linear_J_hom_coeff1]
 value = -68.5532830403637
 type = "float"
-description = "Intercept coefficient for calculating J_hom derived from linear fit of Koop2000 parameterization as shown in CloudMicrophysics.jl docs [-]. DOI:10.1038/35020537."
+description = "Intercept coefficient for a linear fit to the Koop (2000) $J_{hom}$ parameterization (unitless). Source: DOI: 10.1038/35020537."
 
 [Linear_J_hom_coeff2]
 value = 255.9271249999972
 type = "float"
-description = "Slope coefficient for calculating J_hom derived from linear fit of Koop2000 parameterization as shown in CloudMicrophysics.jl docs [-]. DOI:10.1038/35020537."
+description = "Slope coefficient for a linear fit to the Koop (2000) $J_{hom}$ parameterization (unitless). Source: DOI: 10.1038/35020537."
 
-# Microphysics - Luo 1995 H2SO4 vapor pressure
+# Microphysics - H2SO4 Vapor Pressure (Luo et al., 1995)
 
 [p_over_sulphuric_acid_solution_T_max]
 value = 235
 type = "float"
-description = "Maximum valid temperature for calculation of H2SO4 solution vapor pressure [K]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Maximum valid temperature for the H₂SO₄ solution vapor pressure parameterization (K). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_T_min]
 value = 185
 type = "float"
-description = "Minimum valid temperature for calculation of H2SO4 solution vapor pressure [K]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Minimum valid temperature for the H₂SO₄ solution vapor pressure parameterization (K). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_w_2]
 value = 1.4408
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c1]
 value = 23.306
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_1$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c2]
 value = 5.3465
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_2$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c3]
 value = 12
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_3$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c4]
 value = 8.19
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_4$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c5]
 value = -5814
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_5$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c6]
 value = 928.9
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_6$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
 [p_over_sulphuric_acid_solution_c7]
 value = 1876.7
 type = "float"
-description = "Coefficient used for calculation of H2SO4 solution vapor pressure [-]. From Luo et al 1995. DOI: 10.1029/94GL02988."
+description = "Coefficient $c_7$ for the H₂SO₄ solution vapor pressure parameterization (unitless). Source: Luo et al. (1995), DOI: 10.1029/94GL02988."
 
-# Microphysics - Aerosol activation
+# Microphysics - Aerosol Activation
 
 [seasalt_aerosol_molar_mass]
 value = 0.058443
 type = "float"
-description = "Molar mass of aerosol sea salt in kg/mol"
+description = "Molar mass of sea salt aerosol (kg mol⁻¹)."
 
 [seasalt_aerosol_density]
 value = 2170
 type = "float"
-description = "Density of aerosol sea salt in kg/m3"
+description = "Density of sea salt aerosol (kg m⁻³)."
 
 [seasalt_aerosol_osmotic_coefficient]
 value = 0.9
 type = "float"
-description = "Osmotic coefficient of aerosol sea salt [-]"
+description = "Osmotic coefficient of sea salt aerosol (unitless)."
 
 [seasalt_aerosol_ion_number]
 value = 2
 type = "float"
-description = "Number of ions that sea salt dissociates into when dissolved in water [-]"
+description = "Number of ions that sea salt dissociates into when dissolved in water (unitless)."
 
 [seasalt_aerosol_water_soluble_mass_fraction]
 value = 1
 type = "float"
-description = "Mass fraction of water soluble material for sea salt aerosol [-]"
+description = "Mass fraction of water-soluble material for sea salt aerosol (unitless)."
 
 [seasalt_aerosol_kappa]
 value = 1.12
 type = "float"
-description = "Hygroscopicity parameter kappa for sea salt aerosol [-], see: doi.org/10.5194/acp-7-1961-2007"
+description = "Hygroscopicity parameter $\\kappa$ for sea salt aerosol (unitless). Source: DOI: 10.5194/acp-7-1961-2007."
 
 [MERRA2_seasalt_aerosol_bin01_radius]
-value = 0.079e-6
+value = 7.9e-8
 type = "float"
-description = "Dry particle radius associated with sea salt aerosol in bin 01 of the MERRA-2 dataset [m], see: doi.org/10.5067/LTVB4GPCOTK2"
+description = "Dry particle radius for sea salt aerosol in bin 01 of the MERRA-2 dataset (m). Source: DOI: 10.5067/LTVB4GPCOTK2."
 
 [MERRA2_seasalt_aerosol_bin02_radius]
-value = 0.316e-6
+value = 3.16e-7
 type = "float"
-description = "Dry particle radius associated with sea salt aerosol in bin 02 of the MERRA-2 dataset [m], see: doi.org/10.5067/LTVB4GPCOTK2"
+description = "Dry particle radius for sea salt aerosol in bin 02 of the MERRA-2 dataset (m). Source: DOI: 10.5067/LTVB4GPCOTK2."
 
 [MERRA2_seasalt_aerosol_bin03_radius]
 value = 1.119e-6
 type = "float"
-description = "Dry particle radius associated with sea salt aerosol in bin 03 of the MERRA-2 dataset [m], see: doi.org/10.5067/LTVB4GPCOTK2"
+description = "Dry particle radius for sea salt aerosol in bin 03 of the MERRA-2 dataset (m). Source: DOI: 10.5067/LTVB4GPCOTK2."
 
 [MERRA2_seasalt_aerosol_bin04_radius]
 value = 2.818e-6
 type = "float"
-description = "Dry particle radius associated with sea salt aerosol in bin 04 of the MERRA-2 dataset [m], see: doi.org/10.5067/LTVB4GPCOTK2"
+description = "Dry particle radius for sea salt aerosol in bin 04 of the MERRA-2 dataset (m). Source: DOI: 10.5067/LTVB4GPCOTK2."
 
 [MERRA2_seasalt_aerosol_bin05_radius]
 value = 7.772e-6
 type = "float"
-description = "Dry particle radius associated with sea salt aerosol in bin 05 of the MERRA-2 dataset [m], see: doi.org/10.5067/LTVB4GPCOTK2"
+description = "Dry particle radius for sea salt aerosol in bin 05 of the MERRA-2 dataset (m). Source: DOI: 10.5067/LTVB4GPCOTK2."
 
 [sulfate_aerosol_molar_mass]
 value = 0.132
 type = "float"
-description = "Molar mass of aerosol sulfate in kg/mol"
+description = "Molar mass of sulfate aerosol (kg mol⁻¹)."
 
 [sulfate_aerosol_density]
 value = 1770
 type = "float"
-description = "Density of aerosol sulfate in kg/m3"
+description = "Density of sulfate aerosol (kg m⁻³)."
 
 [sulfate_aerosol_osmotic_coefficient]
 value = 1
 type = "float"
-description = "Osmotic coefficient of aerosol sulfate [-]"
+description = "Osmotic coefficient of sulfate aerosol (unitless)."
 
 [sulfate_aerosol_ion_number]
 value = 3
 type = "float"
-description = "Number of ions that sulfate dissociates into when dissolved in water [-]"
+description = "Number of ions that sulfate dissociates into when dissolved in water (unitless)."
 
 [sulfate_aerosol_water_soluble_mass_fraction]
 value = 1
 type = "float"
-description = "Mass fraction of water soluble material for sulfate aerosol [-]"
+description = "Mass fraction of water-soluble material for sulfate aerosol (unitless)."
 
 [sulfate_aerosol_kappa]
 value = 0.53
 type = "float"
-description = "Hygroscopicity parameter kappa for sulfate aerosol [-], see: doi.org/10.5194/acp-7-1961-2007"
+description = "Hygroscopicity parameter $\\kappa$ for sulfate aerosol (unitless). Source: DOI: 10.5194/acp-7-1961-2007."
 
 [MERRA2_sulfate_aerosol_radius]
-value = 0.35e-6
+value = 3.5e-7
 type = "float"
-description = "Dry particle radius associated with sulfate aerosol in the MERRA-2 dataset [m], see: doi.org/10.5067/LTVB4GPCOTK2"
+description = "Dry particle radius for sulfate aerosol in the MERRA-2 dataset (m). Source: DOI: 10.5067/LTVB4GPCOTK2."
 
 [ARG2000_f_coeff_1]
 value = 0.5
 type = "float"
-description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+description = "Scaling coefficient for an empirical function in Abdul-Razzak and Ghan (2000) (unitless). Source: DOI: 10.1029/1999JD901161."
 
 [ARG2000_f_coeff_2]
 value = 2.5
 type = "float"
-description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+description = "Scaling coefficient for an empirical function in Abdul-Razzak and Ghan (2000) (unitless). Source: DOI: 10.1029/1999JD901161."
 
 [ARG2000_g_coeff_1]
 value = 1.0
 type = "float"
-description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+description = "Scaling coefficient for an empirical function in Abdul-Razzak and Ghan (2000) (unitless). Source: DOI: 10.1029/1999JD901161."
 
 [ARG2000_g_coeff_2]
 value = 0.25
 type = "float"
-description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+description = "Scaling coefficient for an empirical function in Abdul-Razzak and Ghan (2000) (unitless). Source: DOI: 10.1029/1999JD901161."
 
 [ARG2000_pow_1]
 value = 1.5
 type = "float"
-description = "Power of (zeta / eta) for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+description = "Exponent for the term ($\\zeta / \\eta$) in an empirical function from Abdul-Razzak and Ghan (2000) (unitless). Source: DOI: 10.1029/1999JD901161."
 
 [ARG2000_pow_2]
 value = 0.75
 type = "float"
-description = "Power of (S_m^2 / (zeta + 3 * eta)) for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+description = "Exponent for the term ($S_m^2 / (\\zeta + 3 \\eta)$) in an empirical function from Abdul-Razzak and Ghan (2000) (unitless). Source: DOI: 10.1029/1999JD901161."
 
-# Microphysics - Modal aerosol model
+# Microphysics - Modal Aerosol Model (MAM3)
 
 [mam3_stdev_coarse]
 value = 1.8
 type = "float"
-description = "Geometric standard deviation for the coarse modal distribution of MAM3. Unitless. From Liu et al., 2012. DOI: 10.5194/gmd-5-709-2012"
+description = "Geometric standard deviation for the coarse mode in the MAM3 scheme (unitless). Source: Liu et al. (2012), DOI: 10.5194/gmd-5-709-2012."
 
 [mam3_stdev_accum]
 value = 1.8
 type = "float"
-description = "Geometric standard deviation for the accumulation modal distribution of MAM3. Unitless. From Liu et al., 2012. DOI: 10.5194/gmd-5-709-2012"
+description = "Geometric standard deviation for the accumulation mode in the MAM3 scheme (unitless). Source: Liu et al. (2012), DOI: 10.5194/gmd-5-709-2012."
 
 [mam3_stdev_ait]
 value = 1.6
 type = "float"
-description = "Geometric standard deviation for the aitken modal distribution of MAM3. Unitless. From Liu et al., 2012. DOI: 10.5194/gmd-5-709-2012"
+description = "Geometric standard deviation for the Aitken mode in the MAM3 scheme (unitless). Source: Liu et al. (2012), DOI: 10.5194/gmd-5-709-2012."
 
-# Nucleation Constants
+# Microphysics - Nucleation Constants (MAM3, Dunne et al., 2016)
 
 [mam3_nucleation_p_b_n_neutral]
 value = 3.95451
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3.  From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $p_{b,n}$ for neutral pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_p_b_i_ion_induced]
 value = 3.373738
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $p_{b,i}$ for ion-induced pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³ and negative ion concentration $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_u_b_n_neutral]
 value = 9.702973
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $u_{b,n}$ for neutral pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_u_b_i_ion_induced]
 value = -11.48166
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $u_{b,i}$ for ion-induced pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³ and negative ion concentration $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_v_b_n_neutral]
 value = 12.62259
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $v_{b,n}$ for neutral pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_v_b_i_ion_induced]
 value = 25.49469
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $v_{b,i}$ for ion-induced pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³ and negative ion concentration $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_w_b_n_neutral]
-value = -0.007066146
+value = -7.066146e-3
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $w_{b,n}$ for neutral pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_w_b_i_ion_induced]
 value = 0.1810722
 type = "float"
-description = "Parameter for pure binary H2SO4-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentration of [H2SO4] is in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $w_{b,i}$ for ion-induced pure binary (H₂SO₄-H₂O) nucleation (unitless). Assumes [H₂SO₄] is in 10⁶ cm⁻³ and negative ion concentration $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_p_t_n_neutral]
 value = 2.891024
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $p_{t,n}$ for neutral pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄] and [NH₃] are in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_p_t_i_ion_induced]
 value = 3.138719
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3.. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $p_{t,i}$ for ion-induced pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄], [NH₃] are in 10⁶ cm⁻³ and $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_u_t_n_neutral]
 value = 182.4495
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $u_{t,n}$ for neutral pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄] and [NH₃] are in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_u_t_i_ion_induced]
 value = -23.8002
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $u_{t,i}$ for ion-induced pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄], [NH₃] are in 10⁶ cm⁻³ and $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_v_t_n_neutral]
 value = 1.203451
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $v_{t,n}$ for neutral pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄] and [NH₃] are in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_v_t_i_ion_induced]
 value = 37.03029
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $v_{t,i}$ for ion-induced pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄], [NH₃] are in 10⁶ cm⁻³ and $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_w_t_n_neutral]
 value = -4.188065
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $w_{t,n}$ for neutral pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄] and [NH₃] are in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_w_t_i_ion_induced]
 value = 0.227413
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $w_{t,i}$ for ion-induced pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄], [NH₃] are in 10⁶ cm⁻³ and $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_p_A_n_neutral]
 value = 8.003471
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $p_{A,n}$ for neutral pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄] and [NH₃] are in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_p_A_i_ion_induced]
 value = 3.071246
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $p_{A,i}$ for ion-induced pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄], [NH₃] are in 10⁶ cm⁻³ and $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_a_n_neutral]
 value = 1.5703478e-6
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $a_n$ for neutral pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄] and [NH₃] are in 10⁶ cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_a_i_ion_induced]
-value = 0.00483140
+value = 4.8314e-3
 type = "float"
-description = "Parameter for pure ternary H2SO4-NH3-H2O nucleation. This is an empirical fit to data and the parameter assumes the concentrations of [H2SO4] and [NH3] are in 10^6 1/cm3 and negative ion concentration [n_] is in 1/cm3. From Dunne et al., 2016. DOI: 10.1126/science.aaf2649."
+description = "Empirical coefficient $a_i$ for ion-induced pure ternary (H₂SO₄-NH₃-H₂O) nucleation (unitless). Assumes [H₂SO₄], [NH₃] are in 10⁶ cm⁻³ and $[n^-]$ is in cm⁻³. Source: Dunne et al. (2016), DOI: 10.1126/science.aaf2649."
 
 [mam3_nucleation_a_1_neutral]
 value = 0.0400097
 type = "float"
-description = "Parameter for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Empirical coefficient $a_{1,n}$ for neutral pure organic nucleation (unitless). Assumes [HOM] is in 10⁷ cm⁻³ and other concentrations have units (TODO). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_a_2_neutral]
 value = 1.84826
 type = "float"
-description = "Parameter for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Empirical coefficient $a_{2,n}$ for neutral pure organic nucleation (unitless). Assumes [HOM] is in 10⁷ cm⁻³ and other concentrations have units (TODO). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_a_3_ion_induced]
-value = 0.00136641
+value = 1.36641e-3
 type = "float"
-description = "Parameter for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3.  From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Empirical coefficient $a_{3,i}$ for ion-induced pure organic nucleation (unitless). Assumes [HOM] is in 10⁷ cm⁻³, $[n^-]$ in cm⁻³, and other concentrations have units (TODO). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_a_4_ion_induced]
 value = 1.56588
 type = "float"
-description = "Parameter for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Empirical coefficient $a_{4,i}$ for ion-induced pure organic nucleation (unitless). Assumes [HOM] is in 10⁷ cm⁻³, $[n^-]$ in cm⁻³, and other concentrations have units (TODO). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_a_5]
 value = 0.186303
 type = "float"
-description = "Parameter for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Empirical coefficient $a_5$ for pure organic nucleation (unitless). Assumes [HOM] is in 10⁷ cm⁻³ and other concentrations have units (TODO). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_Y_MTO3_percent]
 value = 0.029
 type = "float"
-description = "Highly oxygenated organic molecule (HOM) percent yield from monoterpene (MT) oxidation with ozone, used for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Molar yield of highly oxygenated molecules (HOM) from monoterpene (MT) oxidation by O₃ for pure organic nucleation (%). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_Y_MTOH_percent]
 value = 0.012
 type = "float"
-description = "Highly oxygenated organic molecule (HOM) percent yield from monoterpene (MT) oxidation with hydroxyl radicals, used for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Molar yield of highly oxygenated molecules (HOM) from monoterpene (MT) oxidation by OH for pure organic nucleation (%). Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_k_MTO3_organic_factor]
-value =  8.05e-16
+value = 8.05e-16
 type = "float"
-description = "Factor for temperature-dependent rate of monoterpene (MT) oxidation with ozone, used for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Factor for temperature-dependent rate of MT oxidation by O₃ for pure organic nucleation. Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_k_MTOH_organic_factor]
-value =  1.2e-11
+value = 1.2e-11
 type = "float"
-description = "Factor for temperature-dependent rate of monoterpene (MT) oxidation with hydroxyl radicals, used for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Factor for temperature-dependent rate of MT oxidation by OH for pure organic nucleation. Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_exp_MTO3_organic_factor]
 value = -640
 type = "float"
-description = "Additional factor for monoterpene (MT) oxidation with ozone, used for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3. From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Exponent for temperature-dependent rate of MT oxidation by O₃ for pure organic nucleation. Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_exp_MTOH_organic_factor]
-value =  440
+value = 440
 type = "float"
-description = "Additional factor for monoterpene (MT) oxidation with hydroxyl radicals, used for pure organic nucleation. This is an empirical fit to data. The highly oxygenated organic molecules concentration [HOM] is in 10^7 1/cm3, the monoterpene [MT], [OH], and [O3] concentrations are in TODO and the ion concentrations are in 1/cm3.  From Kirkby et al., 2016. DOI: 10.1038/nature17953."
+description = "Exponent for temperature-dependent rate of MT oxidation by OH for pure organic nucleation. Source: Kirkby et al. (2016), DOI: 10.1038/nature17953."
 
 [mam3_nucleation_k_H2SO4_mixed_organic_sulfuric_acid_factor]
-value =  3.27e-21
+value = 3.27e-21
 type = "float"
-description = "Temperature-dependent factor for monoterpene (MT) oxidation with hydroxyl radicals, used for mixed organic-sulfuric acid nucleation. This is an empirical fit to data. The [H2SO4] concentration is in 10^6 1/cm3 and the [BioOxOrg] organics concentration is in 1/cm3. From Riccobno et al., 2014. DOI: 10.1126/science.1243527."
+description = "Temperature-dependent factor for mixed organic-sulfuric acid nucleation. Assumes [H₂SO₄] is in 10⁶ cm⁻³ and [BioOxOrg] is in cm⁻³. Source: Riccobono et al. (2014), DOI: 10.1126/science.1243527."
 
-# Microphysics - ML parameters for cloud droplet number concentration
+# Microphysics - ML Parameters for Cloud Droplet Number Concentration
 
 [dust_calibration_coefficient]
 value = 0
 type = "float"
-desciption = "Coefficient in the data driven cloud droplet number concentration function [-]"
+description = "Calibration coefficient for dust aerosol in the data-driven cloud droplet number concentration function (unitless)."
 
 [seasalt_calibration_coefficient]
 value = 0
 type = "float"
-desciption = "Coefficient in the data driven cloud droplet number concentration function [-]"
+description = "Calibration coefficient for sea salt aerosol in the data-driven cloud droplet number concentration function (unitless)."
 
 [ammonium_sulfate_calibration_coefficient]
 value = 0
 type = "float"
-desciption = "Coefficient in the data driven cloud droplet number concentration function [-]"
+description = "Calibration coefficient for ammonium sulfate aerosol in the data-driven cloud droplet number concentration function (unitless)."
 
-[liquid_water_specific_humidity_calibration_coefficent]
+[liquid_water_specific_humidity_calibration_coefficient]
 value = 0
 type = "float"
-desciption = "Coefficient in the data driven cloud droplet number concentration function [-]"
+description = "Calibration coefficient for liquid water specific humidity in the data-driven cloud droplet number concentration function (unitless)."
 
 [reference_dust_aerosol_mass_concentration]
 value = 1e-8
 type = "float"
-desciption = "Normalization factor for dust aerosol in the data driven cloud droplet number concentration function [kg/kg]"
+description = "Normalization factor for dust aerosol mass concentration in the data-driven CDNC function (kg kg⁻¹)."
 
 [reference_seasalt_aerosol_mass_concentration]
 value = 1e-8
 type = "float"
-desciption = "Normalization factor for sea salt aerosol in the data driven cloud droplet number concentration function [kg/kg]"
+description = "Normalization factor for sea salt aerosol mass concentration in the data-driven CDNC function (kg kg⁻¹)."
 
 [reference_ammonium_sulfate_mass_concentration]
 value = 1e-8
 type = "float"
-desciption = "Normalization factor for ammonium sulfate aerosol in the data driven cloud droplet number concentration function [kg/kg]"
+description = "Normalization factor for ammonium sulfate mass concentration in the data-driven CDNC function (kg kg⁻¹)."
 
 [reference_liquid_water_specific_humidity]
 value = 1e-6
 type = "float"
-description = "Normalization factor for cloud water specific humidity in the data driven cloud droplet number concentration function [kg/kg]"
+description = "Normalization factor for cloud liquid water specific humidity in the data-driven CDNC function (kg kg⁻¹)."
 
-# Initial planet_parameters toml file
+# Thermodynamic Constants
 
-[f_plane_coriolis_frequency]
-value = 0
+[gas_constant_dry_air]
+value = 287.0
 type = "float"
+description = "Gas constant for dry air (J kg⁻¹ K⁻¹)."
+
+[isobaric_specific_heat_dry_air]
+value = 1004.5
+type = "float"
+description = "Isobaric specific heat of dry air (J kg⁻¹ K⁻¹)."
 
 [molar_mass_dry_air]
 value = 0.02897
 type = "float"
+description = "Molar mass of dry air (kg mol⁻¹)."
 
 [adiabatic_exponent_dry_air]
 value = 0.28571428571
 type = "float"
-description = "(2/7)"
+description = "Adiabatic exponent for dry air ($\\kappa_d$), derived from $R_d/c_{pd}$ or 2/7 (unitless)."
 
 [density_liquid_water]
 value = 1000
 type = "float"
+description = "Density of liquid water (kg m⁻³)."
 
 [density_ice_water]
 value = 916.7
 type = "float"
+description = "Density of water ice (kg m⁻³)."
+
+[gas_constant_vapor]
+value = 461.5
+type = "float"
+description = "Gas constant for water vapor (J kg⁻¹ K⁻¹)."
 
 [molar_mass_water]
 value = 0.01801528
 type = "float"
+description = "Molar mass of water (kg mol⁻¹)."
 
 [isobaric_specific_heat_vapor]
 value = 1859
 type = "float"
+description = "Isobaric specific heat of water vapor (J kg⁻¹ K⁻¹)."
 
 [isobaric_specific_heat_liquid]
 value = 4181
 type = "float"
+description = "Isobaric specific heat of liquid water (J kg⁻¹ K⁻¹)."
 
 [isobaric_specific_heat_ice]
 value = 2070.0
 type = "float"
+description = "Isobaric specific heat of ice (J kg⁻¹ K⁻¹)."
 
 [temperature_water_freeze]
 value = 273.15
 type = "float"
+description = "Freezing temperature of water (K)."
 
 [temperature_saturation_adjustment_init_min]
 value = 150
 type = "float"
+description = "Minimum temperature for saturation adjustment initialization (K)."
 
 [temperature_saturation_adjustment_min]
 value = 1
 type = "float"
+description = "Minimum temperature difference for unsaturated case in saturation adjustment (K)."
 
 [temperature_saturation_adjustment_max]
 value = 1000
 type = "float"
+description = "Maximum temperature for saturation adjustment (K)."
 
 [temperature_homogenous_nucleation]
 value = 233
 type = "float"
+description = "Temperature for homogeneous ice nucleation (K)."
 
 [pow_icenuc]
 value = 1
 type = "float"
+description = "Exponent in the ice nucleation parameterization (unitless)."
 
 [microph_scaling_acnv]
 value = 1.0
 type = "float"
+description = "Scaling factor for autoconversion in microphysics (unitless)."
 
 [microph_scaling_accr]
 value = 1.0
 type = "float"
+description = "Scaling factor for accretion in microphysics (unitless)."
 
 [microph_scaling_evap]
 value = 1.0
 type = "float"
+description = "Scaling factor for evaporation in microphysics (unitless)."
 
 [microph_scaling_dep_sub]
 value = 1.0
 type = "float"
+description = "Scaling factor for deposition/sublimation in microphysics (unitless)."
 
 [microph_scaling_melt]
 value = 1.0
 type = "float"
+description = "Scaling factor for melting in microphysics (unitless)."
 
 [temperature_triple_point]
 value = 273.16
 type = "float"
+description = "Triple point temperature of water (K)."
 
 [thermodynamics_temperature_reference]
 value = 273.16
 type = "float"
-
+description = "Reference temperature for thermodynamics (K)."
 
 [latent_heat_vaporization_at_reference]
 value = 2500800
 type = "float"
+description = "Latent heat of vaporization at the reference temperature (J kg⁻¹)."
 
 [latent_heat_sublimation_at_reference]
 value = 2834400
 type = "float"
+description = "Latent heat of sublimation at the reference temperature (J kg⁻¹)."
 
 [pressure_triple_point]
 value = 611.657
 type = "float"
+description = "Triple point pressure of water (Pa)."
 
 [surface_tension_water]
 value = 0.072
 type = "float"
+description = "Surface tension of water (N m⁻¹)."
 
 [entropy_dry_air]
 value = 6864.8
 type = "float"
+description = "Specific entropy of dry air at the reference temperature and pressure (J kg⁻¹ K⁻¹)."
 
 [entropy_water_vapor]
 value = 10513.6
 type = "float"
+description = "Specific entropy of water vapor at the reference temperature and pressure (J kg⁻¹ K⁻¹)."
 
 [entropy_reference_temperature]
 value = 298.15
 type = "float"
+description = "Reference temperature for entropy calculations (K)."
 
 [density_ocean_reference]
 value = 1035
 type = "float"
+description = "Reference density of sea water (kg m⁻³)."
 
 [specific_heat_ocean]
-value = 3989.25
+value = 3991.86795711963
 type = "float"
+description = "Specific heat of sea water (J kg⁻¹ K⁻¹)."
+
+# Planetary and Orbital Parameters (Earth Defaults)
 
 [planet_radius]
 value = 6371000
 type = "float"
+description = "Mean radius of the planet (m)."
 
 [day]
 value = 86400
 type = "float"
+description = "Length of a day (s)."
 
 [angular_velocity_planet_rotation]
-value = 0.000072921159
+value = 7.2921159e-5
 type = "float"
+description = "Angular velocity of planetary rotation ($\\Omega$) (rad s⁻¹)."
+
+[f_plane_coriolis_frequency]
+value = 0
+type = "float"
+description = "Coriolis frequency on an f-plane (s⁻¹)."
 
 [gravitational_acceleration]
 value = 9.81
 type = "float"
+description = "Gravitational acceleration on the planet (m s⁻²)."
 
 [anomalistic_year_length]
 value = 31558464
 type = "float"
-description = "derived: 365.25 * [day]"
+description = "Length of an anomalistic year (s). Derived as 365.25 * `day`."
 
 [length_orbit_semi_major]
 value = 149597870000
 type = "float"
-description = "derived: 1 * [astronomical_unit]"
+description = "Semi-major axis of the planetary orbit (m). Derived as 1 * `astronomical_unit`."
 
 [total_solar_irradiance]
 value = 1362
 type = "float"
+description = "Total solar irradiance (TSI) at the mean orbital distance (W m⁻²)."
 
 [epoch_time]
 value = 211813488000
 type = "float"
-description = "derived: 2451545.0 * [day]"
+description = "Epoch time (s). Derived as 2451545.0 * `day`."
 
-[mean_anomalistic_at_epoch]
+[mean_anomaly_at_epoch]
 value = 6.24006014121
 type = "float"
-description = "(357.52911 degrees) in radians"
+description = "Mean anomaly at epoch (radians). Corresponds to 357.52911°."
 
 [orbit_obliquity_at_epoch]
 value = 0.408979125113246
 type = "float"
-description = "(23.432777778 degrees) in radians"
+description = "Obliquity of the ecliptic at epoch (radians). Corresponds to 23.43278°."
 
 [longitude_perihelion_at_epoch]
 value = 4.938188299449
 type = "float"
-description = "(282.937348 degrees) in radians"
+description = "Longitude of perihelion at epoch (radians). Corresponds to 282.9373°."
 
 [orbit_eccentricity_at_epoch]
 value = 0.016708634
 type = "float"
+description = "Orbital eccentricity at epoch (unitless)."
 
 [longitude_perihelion]
 value = 4.938188299449
 type = "float"
-description = "(282.937348 degrees) in radians"
+description = "Longitude of perihelion (radians). Corresponds to 282.9373°."
+
+# Universal Physical Constants
 
 [potential_temperature_reference_pressure]
-value = 100000
+value = 1e5
 type = "float"
-description = "Reference pressure used in potential temperature definition"
+description = "Reference pressure for potential temperature calculations ($p_0$) (Pa)."
 
 [mean_sea_level_pressure]
 value = 101325
 type = "float"
+description = "Mean sea level pressure ($p_{MSL}$) (Pa)."
 
-[temperature_mean_at_reference]
+[temperature_surface_reference]
 value = 290
 type = "float"
+description = "Surface temperature in a reference temperature profile (K)."
 
-[temperature_min_at_reference]
+[temperature_min_reference]
 value = 220
 type = "float"
+description = "Minimum temperature in a reference temperature profile (K)."
 
-[gas_constant]
+[universal_gas_constant]
 value = 8.3144598
 type = "float"
+description = "Universal gas constant (R) (J mol⁻¹ K⁻¹)."
 
 [light_speed]
 value = 299792458
 type = "float"
+description = "Speed of light in vacuum (c) (m s⁻¹)."
 
 [planck_constant]
 value = 6.626e-34
 type = "float"
+description = "Planck's constant (h) (J s)."
 
-[bolztmann_constant]
+[boltzmann_constant]
 value = 1.381e-23
 type = "float"
+description = "Boltzmann's constant ($k_B$) (J K⁻¹)."
 
 [stefan_boltzmann_constant]
 value = 5.67e-8
 type = "float"
+description = "Stefan-Boltzmann constant ($\\sigma$) (W m⁻² K⁻⁴)."
 
 [astronomical_unit]
 value = 149597870000
 type = "float"
+description = "Astronomical unit (AU) (m)."
 
 [avogadro_constant]
-value = 6.02214076e23
+value = 6.02214076e+23
 type = "float"
+description = "Avogadro's constant ($N_A$) (mol⁻¹)."
+
+# Diffusion
 
 [tracer_hyperdiffusion_factor]
 value = 0
 type = "float"
-description = "Scaling factor for hyperdiffusion of fields that have strong gradients, e.g. precipitation (unitless)"
+description = "Scaling factor for hyperdiffusion of tracers with strong gradients, e.g., precipitation (unitless)."
 
 [C_E]
 value = 0.0044
 type = "float"
-description = "vertical diffusion coefficient"
+description = "Coefficient used in the simple vertical diffusion scheme ($C_E$) (unitless)."
 
 [C_H]
 value = 0.0044
 type = "float"
-description = "bulk transfer coefficient"
+description = "Bulk transfer coefficient for sensible heat ($C_H$) (unitless)."
 
 [D_0_diffusion]
 value = 5
 type = "float"
-description = "Coefficient in DecayWithHeightDiffusion vertical diffusion scheme [m2/s]"
+description = "Coefficient $D_0$ in the DecayWithHeightDiffusion vertical diffusion scheme (m² s⁻¹)."
 
 [H_diffusion]
 value = 8000
 type = "float"
-description = "Height scale in DecayWithHeightDiffusion vertical diffusion scheme [m]"
+description = "Height scale $H$ in the DecayWithHeightDiffusion vertical diffusion scheme (m)."
 
 [tracer_vertical_diffusion_factor]
 value = 1
 type = "float"
-description = "Scaling factor for vertical diffusion of fields that have strong gradients, e.g. precipitation (unitless)"
+description = "Scaling factor for vertical diffusion of tracers with strong gradients, e.g., precipitation (unitless)."
 
 # Rayleigh Damping
 
 [alpha_rayleigh_w]
 value = 1.0
 type = "float"
-description = "rayleigh sponge coefficient for vertical velocity"
+description = "Coefficient $\\alpha_w$ for Rayleigh damping on vertical velocity (s⁻¹)."
 
 [alpha_rayleigh_uh]
 value = 0.0
 type = "float"
-description = "rayleigh sponge coefficient for horizontal velocity"
+description = "Coefficient $\\alpha_{uh}$ for Rayleigh damping on horizontal velocity (s⁻¹)."
 
 [alpha_rayleigh_sgs_tracer]
 value = 0.0
 type = "float"
-description = "rayleigh sponge coefficient for subgrid-scale tracer"
+description = "Coefficient $\\alpha_{sgs_tracer}$ for Rayleigh damping on subgrid-scale tracer (s⁻¹)"
 
 [zd_rayleigh]
 value = 15000.0
 type = "float"
-description = "rayleigh sponge starting height"
+description = "Height at which Rayleigh damping begins in the sponge layer ($z_d$) (m)."
 
 [zd_viscous]
 value = 15000.0
 type = "float"
-description = "viscous sponge starting height"
+description = "Height at which viscous damping begins in the sponge layer (m)."
 
 [kappa_2_sponge]
-value = 1.0e6
+value = 1e6
 type = "float"
-description = "viscous sponge coefficient"
+description = "Viscous sponge coefficient ($\\kappa_2$) (m² s⁻¹)."
 
-# Held-Suarez
+# Held-Suarez Benchmark
 
 [held_suarez_T_equator_dry]
 value = 315
 type = "float"
-description = "Equator temperature. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Equatorial temperature for the dry Held-Suarez benchmark (K). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
 [held_suarez_T_equator_wet]
 value = 294
 type = "float"
-description = "Equator temperature. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Equatorial temperature for the moist Held-Suarez benchmark (K). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
 [potential_temp_vertical_gradient]
 value = 10
 type = "float"
-description = "Potential temperature gradient with height. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Vertical gradient of potential temperature with height (K m⁻¹). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
 [drag_layer_vertical_extent]
 value = 0.7
 type = "float"
-description = "Vertical extend of drag layer. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Vertical extent of the drag layer as a fraction of total pressure depth (unitless). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
 [held_suarez_minimum_temperature]
 value = 200
 type = "float"
-description = "Minimum temperature. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Minimum temperature allowed in the benchmark (K). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
 [equator_pole_temperature_gradient_dry]
 value = 60
 type = "float"
-description = "Temperature gradient between equator and pole for dry adiabatic atmosphere. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Equator-to-pole temperature gradient for the dry benchmark (K). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
 [equator_pole_temperature_gradient_wet]
 value = 65
 type = "float"
-description = "Temperature gradient between equator and pole for moist adiabatic atmosphere. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+description = "Equator-to-pole temperature gradient for the moist benchmark (K). Source: Held and Suarez (1994), DOI: 10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2."
 
-# radiation
-[ocean_surface_albedo]
+# Radiation
+
+[idealized_ocean_albedo]
 value = 0.38
 type = "float"
-description = "Ocean surface albedo for idealized simulations. See O'Gorman and Schneider (2008) [https://journals.ametsoc.org/view/journals/clim/21/15/2007jcli2065.1.xml]"
+description = "Ocean surface albedo for idealized simulations (unitless). Source: O'Gorman and Schneider (2008)."
 
 [water_refractive_index]
 value = 1.34
 type = "float"
-description = "The relative refractive index of water and air for broadband ocean surface albedo calculation. See Jin et al. (2011) [https://opg.optica.org/oe/fulltext.cfm?uri=oe-19-27-26429&id=225797]"
+description = "Relative refractive index of water and air for broadband ocean surface albedo calculation (unitless). Source: Jin et al. (2011)."
 
 [optics_lookup_temperature_min]
 value = 160
 type = "float"
-description = "Miminum temperature in the lookup table for optical properties in RRTMGP"
+description = "Minimum temperature in the lookup table for optical properties in RRTMGP (K)."
 
 [optics_lookup_temperature_max]
 value = 355
 type = "float"
-description = "Maximum temperature in the lookup table for optical properties in RRTMGP"
+description = "Maximum temperature in the lookup table for optical properties in RRTMGP (K)."
 
-# RCEMIP
+# RCEMIP Benchmark
 
 [SST_mean]
 value = 300
 type = "float"
-description = "Mean sea surface temperature for RCEMIPII surface conditions. See Wing et al. (2018) [https://gmd.copernicus.org/articles/11/793/2018/]"
+description = "Mean sea surface temperature (SST) for RCEMIP surface conditions (K). Source: Wing et al. (2018)."
 
 [SST_delta]
 value = 1.25
 type = "float"
-description = "Twice the amplitude of sea surface temperarture sinusoid for RCEMIPII surface conditions. See Wing et al. (2018) [https://gmd.copernicus.org/articles/11/793/2018/]"
+description = "Amplitude of the SST sinusoid for RCEMIP surface conditions (K). Note: value is $2 \times$ amplitude. Source: Wing et al. (2018)."
 
 [SST_wavelength]
-value = 6000000
+value = 6e6
 type = "float"
-description = "Wavelength of the sea surface temperature sinusoid for RCEMIPII box models. See Wing et al. (2018) [https://gmd.copernicus.org/articles/11/793/2018/]"
+description = "Wavelength of the SST sinusoid for RCEMIP box models (m). Source: Wing et al. (2018)."
 
 [SST_wavelength_latitude]
 value = 54
 type = "float"
-description = "Wavelength of the sea surface temperature sinusoid for RCEMIPII sphere models. See Wing et al. (2018) [https://gmd.copernicus.org/articles/11/793/2018/]"
+description = "Wavelength of the SST sinusoid for RCEMIP sphere models (degrees latitude). Source: Wing et al. (2018)."
 
-# EDMF
+# EDMF Scheme
 
 [entr_param_vec]
 value = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 type = "float"
-description = "Data-driven entrainment parameter vector"
+description = "Data-driven entrainment parameter vector (unitless)."
 
 [entr_mult_limiter_coeff]
 value = 0.0
 type = "float"
-description = "Exponent for multiplicative entrainment limiter of the form (1 - area)^c"
+description = "Exponent for the multiplicative entrainment limiter of the form $(1 - area)^c$ (unitless)."
 
 [turb_entr_param_vec]
 value = [0.0, 0.0, 0.0]
 type = "float"
-description = "Data-driven turbulent entrainment parameter vector"
+description = "Data-driven turbulent entrainment parameter vector (unitless)."
 
 [entr_inv_tau]
 value = 0.001
 type = "float"
-description = "Entrainment inverse timescale"
+description = "Inverse timescale for entrainment (s⁻¹)."
 
 [entr_coeff]
 value = 1
 type = "float"
-description = "Coefficient for the w/z term in the entrainment closure. Parameter not described in the literature."
+description = "Coefficient for the $w/z$ term in the entrainment closure (unitless)."
 
 [entr_vertdiv_coeff]
 value = 1
 type = "float"
-description = "Coefficient for the vertical divergence term in the entrainment closure. Parameter not described in the literature."
+description = "Coefficient for the vertical divergence term in the entrainment closure (unitless)."
 
 [min_area_limiter_scale]
-value = 1e-3
+value = 0.001
 type = "float"
-description = "Constant coefficient that scales the minimum area limiter term in entrainment. Parameter not described in the literature."
+description = "Scaling coefficient for the minimum area limiter in entrainment (unitless)."
 
 [min_area_limiter_power]
 value = 10
 type = "float"
-description = "Constant coefficient for the exponent in the minimum area limiter term in entrainment. Parameter not described in the literature."
+description = "Exponent for the minimum area limiter in entrainment (unitless)."
 
 [detr_inv_tau]
 value = 0.001
 type = "float"
-description = "Detrainment inverse timescale"
+description = "Inverse timescale for detrainment (s⁻¹)."
 
 [detr_coeff]
 value = 0.001
 type = "float"
-description = "Coefficient for the w term in the detrainment closure. Parameter not described in the literature."
+description = "Coefficient for the $w$ term in the detrainment closure (unitless)."
 
 [detr_buoy_coeff]
 value = 0.12
 type = "float"
-description = "Coefficient for the b/w^2 term in the detrainment closure. See Tan et al. (2018) [https://doi.org/10.1002/2017MS001162], Eq 27."
+description = "Coefficient for the $b/w^2$ term in the detrainment closure (unitless). Source: Tan et al. (2018), Eq. 27."
 
 [detr_vertdiv_coeff]
 value = 1
 type = "float"
-description = "Coefficient for the vertical divergence term in the detrainment closure. Parameter not described in the literature."
+description = "Coefficient for the vertical divergence term in the detrainment closure (unitless)."
 
 [detr_massflux_vertdiv_coeff]
 value = 1
 type = "float"
-description = "Coefficient for the mass flux vertical divergence term in the detrainment closure. Parameter not described in the literature."
+description = "Coefficient for the mass flux vertical divergence term in the detrainment closure (unitless)."
 
 [detr_ramp_z_start]
 value = 20000.0
 type = "float"
-description = "Start height of the sigmoid ramp for detrainment top limiter (m). Prevents updrafts from hitting domain top."
+description = "Start height of the sigmoid ramp for the detrainment top limiter (m)."
 
 [detr_ramp_steepness_factor]
 value = 10.0
 type = "float"
-description = "Factor used to calculate the steepness of the sigmoid ramp for detrainment top limiter. Steepness = factor / (z_end - z_start). Prevents updrafts from hitting domain top."
+description = "Factor for calculating the steepness of the sigmoid ramp for the detrainment top limiter. Steepness = factor / (z_end - z_start)."
 
 [max_area_limiter_scale]
 value = 0.1
 type = "float"
-description = "Constant coefficient that scales the maximum area limiter term in detrainment. Parameter not described in the literature."
+description = "Scaling coefficient for the maximum area limiter in detrainment (unitless)."
 
 [max_area_limiter_power]
 value = 10
 type = "float"
-description = "Constant coefficient for the exponent in the maximum area limiter term in detrainment. Parameter not described in the literature."
+description = "Exponent for the maximum area limiter in detrainment (unitless)."
 
 [c_smag]
 value = 0.2
 type = "float"
-description = "Smagorinsky coefficient"
+description = "Smagorinsky coefficient (unitless)."
 
 [EDMF_surface_area]
 value = 0.1
 type = "float"
-description = "Combined updraft surface area fraction; used to compute boundary conditions for prognostic updraft variables. The surface area for each updraft is `surface_area / N_updrafts`. See Cohen et al. (2020) [https://doi.org/10.1029/2020MS002162], Table 2."
+description = "Combined updraft surface area fraction (unitless). The surface area for each updraft is `surface_area / N_updrafts`. Source: Cohen et al. (2020), Table 2."
 
 [EDMF_max_area]
 value = 0.9
 type = "float"
-description = "Maximum area fraction per updraft. Parameter not described in the literature."
+description = "Maximum area fraction per updraft (unitless)."
 
 [EDMF_min_area]
-value = 1.0e-5
+value = 1e-5
 type = "float"
-description = "Minimum area fraction per updraft. Parameter not described in the literature."
+description = "Minimum area fraction per updraft (unitless)."
 
 [mixing_length_eddy_viscosity_coefficient]
 value = 0.14
 type = "float"
-description = "Turbulence kinetic energy diffusivity coefficient for the EDMF mixing length closure; denoted c_m. See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002162], Table 1."
+description = "TKE diffusivity coefficient ($c_m$) for the EDMF mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Table 1."
 
 [mixing_length_diss_coeff]
 value = 0.22
 type = "float"
-description = "Turbulence kinetic energy dissipation coefficient for the EDMF mixing length closure; denoted c_d. See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002162], Table 1."
+description = "TKE dissipation coefficient ($c_d$) for the EDMF mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Table 1."
 
 [mixing_length_static_stab_coeff]
 value = 0.4
 type = "float"
-description = "Static stability coefficient for the EDMF mixing length closure; denoted c_b. See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002162], Table 1."
+description = "Static stability coefficient ($c_b$) for the EDMF mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Table 1."
 
 [mixing_length_tke_surf_scale]
 value = 3.75
 type = "float"
-description = "Ratio of turbulence kinetic energy to squared friction velocity in the surface layer for the EDMF mixing length closure; denoted κ_*². See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002162], Table 1. Note: the square root, i.e. κ_*, is listed in the reference."
+description = "Ratio of TKE to squared friction velocity ($\\kappa_*²$) in the surface layer for the EDMF mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Table 1."
 
 [mixing_length_tke_surf_flux_coeff]
 value = 2.5
 type = "float"
-description = "Coefficient multiplying flux in ustar^3 surface flux formulation of tke (tke_surf_flux_coeff * ρ * ustar^3)"
+description = "Coefficient multiplying flux in the $u_*^3$ surface flux formulation of TKE ($C_{flux}$) (unitless)."
 
 [mixing_length_Prandtl_number_scale]
 value = 4.076923076923077
 type = "float"
-description = "Cospectral budget factor for turbulent Prandtl number for the EDMF mixing length closure, denoted ω_pr. In Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002162], Eq. 36, it is described as a phenomenological constant, denoted by ω₂ and set to 53/13 ≈ 4.0769..."
+description = "Cospectral budget factor for turbulent Prandtl number ($\\omega_{pr}$) for the EDMF mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Eq. 36."
 
 [mixing_length_Prandtl_number_0]
 value = 0.74
 type = "float"
-description = "Turbulent Prandtl number in neutral conditions; denoted Pr_{t,0}. See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002162], Table 1 and Eq 36."
+description = "Turbulent Prandtl number in neutral conditions ($Pr_{t,0}$) (unitless). Source: Lopez-Gomez et al. (2020), Table 1."
 
 [mixing_length_Prandtl_maximum]
 value = 10
 type = "float"
-description = "Maximum allowed Prandtl number"
+description = "Maximum allowed turbulent Prandtl number (unitless)."
 
 [mixing_length_Ri_crit]
 value = 0.25
 type = "float"
-description = "Critical gradient Richardson number. It is an upper limit to the gradient Richardson number . See Li (2019) [https://doi.org/10.1016/j.atmosres.2018.09.015], Section 6.2 for details."
+description = "Critical gradient Richardson number ($Ri_{crit}$) (unitless). Source: Li (2019), Section 6.2."
 
 [mixing_length_smin_ub]
 value = 0.1
 type = "float"
-description = "Lower limit for smooth minimum function in mixing length closure. See Lopez-Gomez et al. (2020) Eq 40 [https://doi.org/10.1029/2020MS002161]."
+description = "Lower limit for the smooth minimum function in the mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Eq. 40."
 
 [mixing_length_smin_rm]
 value = 1.5
 type = "float"
-description = "Upper ratio limit for smooth minimum function in mixing length closure. See Lopez-Gomez et al. (2020) Eq 40 [https://doi.org/10.1029/2020MS002161]."
+description = "Upper ratio limit for the smooth minimum function in the mixing length closure (unitless). Source: Lopez-Gomez et al. (2020), Eq. 40."
 
 [mixing_length_l_max]
-value = 1.0e6
+value = 1e6
 type = "float"
-description = "Upper limit for length scale limiter in mixing length closure. See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002161]."
+description = "Upper limit for the length scale in the mixing length closure (m). Source: Lopez-Gomez et al. (2020)."
 
 [mixing_length_l_min]
 value = 10
 type = "float"
-description = "Lower limit for mixing length. Parameter not described in the literature."
+description = "Lower limit for the mixing length (m)."
 
 [mixing_length_param_vec]
 value = [0.0, 0.0, 0.0, 0.0, 0.0]
 type = "float"
-description = "Data-driven mixing length parameter vector"
+description = "Data-driven mixing length parameter vector (unitless)."
 
 [entrainment_factor]
 value = 0.13
 type = "float"
-description = "Scaling constant for entrainment rate. See Cohen et al. (2022) Table 2 & Eq 39, 40 [https://doi.org/10.1029/2020MS002162]."
+description = "Scaling constant for entrainment rate (unitless). Source: Cohen et al. (2022), Table 2."
 
 [detrainment_factor]
 value = 0.51
 type = "float"
-description = "Scaling constant for detrainment rate. See Cohen et al. (2022) Table 2 & Eq 39, 40 [https://doi.org/10.1029/2020MS002162]."
+description = "Scaling constant for detrainment rate (unitless). Source: Cohen et al. (2022), Table 2."
 
 [turbulent_entrainment_factor]
 value = 0.075
 type = "float"
-description = "Scaling constant for turbulent entrainment rate. See Cohen et al. (2022) Table 2 & eqn. 46 [https://doi.org/10.1029/2020MS002162]."
+description = "Scaling constant for turbulent entrainment rate (unitless). Source: Cohen et al. (2022), Table 2."
 
 [entrainment_smin_tke_coeff]
 value = 0.3
 type = "float"
-description = "Scaling constant of TKE term in entrainment/detrainment inverse timescale smooth minimum.  See Cohen et al. (2022) Table 2 & eqn. 30 [https://doi.org/10.1029/2020MS002162]."
+description = "Scaling constant of the TKE term in the entrainment/detrainment inverse timescale smooth minimum (unitless). Source: Cohen et al. (2022), Table 2."
 
 [updraft_mixing_frac]
 value = 0.25
 type = "float"
-description = "Fraction of updraft air for buoyancy mixing in entrainment/detrainment formulation. See Cohen et al. (2022) Table 2 & eqn. 36 [https://doi.org/10.1029/2020MS002162]."
+description = "Fraction of updraft air used for buoyancy mixing in the entrainment/detrainment formulation (unitless). Source: Cohen et al. (2022), Table 2."
 
 [entrainment_area_limiter_scale]
 value = 4.0
 type = "float"
-description = "Constant scaling factor (amplitude) of exponential detrainment area limiter. Parameter not described in the literature."
+description = "Scaling factor (amplitude) of the exponential detrainment area limiter (unitless)."
 
 [entrainment_area_limiter_power]
 value = 10.0
 type = "float"
-description = "Exponential decay constant in detrainment area limiter. Parameter not described in the literature."
+description = "Exponential decay constant in the detrainment area limiter (unitless)."
 
 [entrainment_scale]
 value = 0.0004
 type = "float"
-description = "Dimensional constant scaling logistic function argument in entrainment/detrainment dry term. See Cohen et al. (2022) Table 2 & eqn. 37 [https://doi.org/10.1029/2020MS002162]."
+description = "Dimensional constant scaling the logistic function argument in the entrainment/detrainment dry term. Source: Cohen et al. (2022), Table 2."
 
 [entrainment_sorting_power]
 value = 2.0
 type = "float"
-description = "Sorting power for moisture term in entrainment/detrainment formulation. Controls the magnitude of the evaporative potential for a given relative humidity difference. See Cohen et al. (2022) Table 2 & eqn. 38 [https://doi.org/10.1029/2020MS002162]."
+description = "Sorting power for the moisture term in the entrainment/detrainment formulation (unitless). Source: Cohen et al. (2022), Table 2."
 
 [minimum_updraft_velocity]
 value = 0.001
 type = "float"
-description = "Minimum updraft-environment vertical velocity difference allowable when computing inverse length scale in entrainment/detrainment formulation. Parameter not described in the literature."
+description = "Minimum updraft-environment vertical velocity difference (m s⁻¹)."
 
 [minimum_updraft_top]
 value = 500.0
 type = "float"
-description = "Minimum updraft height limiter to avoid zero division in pressure drag and entrainment/detrainment closures. Parameter not described in the literature."
+description = "Minimum updraft height limiter (m)."
 
 [pressure_normalmode_buoy_coeff1]
 value = 0.12
 type = "float"
-description = "Pressure buoyancy coefficient (encapsulating virtual mass loading effect) in perturbation pressure closure. See He et al. 2022 Eq 34 [https://doi.org/10.1002/essoar.10505084.2]."
+description = "Pressure buoyancy coefficient in the perturbation pressure closure (unitless). Source: He et al. (2022), Eq. 34."
 
 [pressure_normalmode_adv_coeff]
 value = 0.1
 type = "float"
-description =  "Pressure advection (advection damping) coefficient in perturbation pressure closure. See He et al. 2022 Eq 34 [https://doi.org/10.1002/essoar.10505084.2]."
+description = "Pressure advection (damping) coefficient in the perturbation pressure closure (unitless). Source: He et al. (2022), Eq. 34."
 
 [pressure_normalmode_drag_coeff]
 value = 10.0
 type = "float"
-description = "Updraft pressure drag coefficent in perturbation pressure closure. See He et al. 2022 Eq 34 [https://doi.org/10.1002/essoar.10505084.2]."
+description = "Updraft pressure drag coefficient in the perturbation pressure closure (unitless). Source: He et al. (2022), Eq. 34."
 
 [pressure_normalmode_param_vec]
 value = [0.0, 0.0, 0.0, 0.0, 0.0]
 type = "float"
-description = "Data-driven perturbation pressure parameter vector"
+description = "Data-driven perturbation pressure parameter vector (unitless)."
 
 [EDMF_thermodynamics_moisture_model]
 value = "equilibrium"
 type = "string"
-description = " Edmf moisture model choice. The default (equilibrium) results in diagnosing cloud liquid and ice water content using saturation adjustment. An experimental nonequilibrium option introduces prognostic equations for cloud liquid and cloud ice.  Not documented in the literature (yet) - Benjamin et.al. in prep."
+description = "Moisture model for EDMF thermodynamics. Options: 'equilibrium' (default), 'nonequilibrium'."
 
 [EDMF_thermodynamics_covariance_model]
 value = "diagnostic"
 type = "string"
-description = "Edmf covaraince model choice. Valid options are diagnostic (default) and prognostic."
+description = "Covariance model for EDMF thermodynamics. Options: 'diagnostic' (default), 'prognostic'."
 
 [diagnostic_covariance_coeff]
 value = 2.1
 type = "float"
-description = "Prefactor used in turbulent production term of EDMF covariance equation."
+description = "Prefactor in the turbulent production term of the EDMF covariance equation (unitless)."
 
 [EDMF_thermodynamics_diagnostic_covar_limiter]
-value = 0.001
+value = 1e-3
 type = "float"
-description = "Regularization epsilon used in the denominator when computing covariances diagnostically."
+description = "Regularization epsilon for the denominator in diagnostic covariance calculations (unitless)."
 
 [EDMF_thermodynamics_sgs]
 value = "mean"
 type = "string"
-description = "Edmf environmental sub-grid scale model choice. Valid options are mean (default) and quadrature. The quadrature option switches on numerical sampling of 2-dimensional PDFs of edmf environmental state variables. Not documented in the literature (yet) - Jaruga et al in prep."
+description = "Environmental sub-grid scale model for EDMF. Options: 'mean' (default), 'quadrature'."
 
 [EDMF_thermodynamics_quadrature_order]
 value = 3
 type = "integer"
-description = "Number of numerical quadrature sampling points in one dimension. Valid when running edmf with sgs quadrature choice. Not documented in the literature (yet) - Jaruga et al in prep."
+description = "Number of 1D quadrature points for SGS sampling in EDMF."
 
 [EDMF_thermodynamics_quadrature_type]
 value = "log-normal"
 type = "string"
-description = "Assumed distribution shape of the edmf state variables (q_tot and \theta_liq_ice) in the environment. Valid options are log-normal (default) and gaussian. Valid when running edmf with sgs quadrature choice. Not documented in the literature (yet) - Jaruga et al in prep."
+description = "Assumed PDF shape for environmental variables ($q_{tot}, \\theta_{liq_ice}$) with SGS quadrature. Options: 'log-normal' (default), 'gaussian'."
 
 [updraft_number]
 value = 1
 type = "integer"
-description = "Number of edmf updrafts."
+description = "Number of updrafts in the EDMF scheme."
 
 [gcmdriven_momentum_relaxation_timescale]
 value = 21600.0
 type = "float"
-description = "Horizontal wind relaxation timescale toward forcing profile in SCM cases (in seconds). Parameter described in 2.2.3 of Shen et al. 2022 [https://doi.org/10.1029/2021MS002631]."
+description = "Relaxation timescale for horizontal winds toward the forcing profile in Single Column Model (SCM) cases (s). Source: Shen et al. (2022)."
 
 [gcmdriven_scalar_relaxation_timescale]
 value = 86400.0
 type = "float"
-description = "Scalar relaxation timescale used to relax temperature and humidities toward forcing profile in SCM cases (in seconds). Parameter described in 2.2.3 Eq 11 of Shen et al. 2022 [https://doi.org/10.1029/2021MS002631]."
+description = "Relaxation timescale for scalars (temperature, humidity) toward the forcing profile in SCM cases (s). Source: Shen et al. (2022)."
 
 [gcmdriven_relaxation_minimum_height]
 value = 3000.0
 type = "float"
-description = "Starting height for relaxation towards forcing profile in SCM cases (in meters). Parameter described in 2.2.3 Eq 11 of Shen et al. 2022 [https://doi.org/10.1029/2021MS002631]."
+description = "Start height for relaxation toward the forcing profile in SCM cases (m). Source: Shen et al. (2022)."
 
 [gcmdriven_relaxation_maximum_height]
 value = 3500.0
 type = "float"
-description = "Height for relaxation towards forcing profile in SCM cases at which the relaxation timescale coefficient becomes 1 (in meters). Parameter described in 2.2.3 Eq 11 of Shen et al. 2022 [https://doi.org/10.1029/2021MS002631]."
+description = "Height at which the relaxation coefficient becomes 1 in SCM cases (m). Source: Shen et al. (2022)."
 
 [microphysics_model_precipitation_fraction]
 value = "prescribed"
 type = "string"
-description = "Precipitation fraction model choice. Options are prescribed (default) and cloud_cover. Valid for simulations running with the 1-moment microphysics scheme, edmf turbulence convection model. Not documented in the literature (yet)."
+description = "Precipitation fraction model choice for 1-moment microphysics with EDMF. Options: 'prescribed' (default), 'cloud_cover'."
 
 [microphysics_prescribed_precipitation_fraction]
 value = 1.0
 type = "float"
-description = "Prescribed value of precipitation fraction. Should be between 0 and 1. Valid for simulations running with the 1-moment microphysics scheme, edmf turbulence convection model and prescribed precip_fraction_model. Not documented in the literature (yet)."
+description = "Prescribed value of the precipitation fraction (unitless)."
 
 [microphysics_precipitation_fraction_limiter]
 value = 0.3
 type = "float"
-description = "Minimum precipitation fraction allowed. Should be between 0 and 1. Valid for simulations running with the 1-moment microphysics scheme, edmf turbulence convection model and cloud_cover precip_fraction_model. Not documented in the literature (yet)."
+description = "Minimum allowed precipitation fraction when using the 'cloud_cover' model (unitless)."

--- a/test/param_boxes.jl
+++ b/test/param_boxes.jl
@@ -6,15 +6,15 @@ import ClimaParams as CP
 
 Base.@kwdef struct ParameterBox{FT}
     molmass_dryair::FT
-    gas_constant::FT
+    universal_gas_constant::FT
     new_parameter::FT
 end
 
 # Derived parameters
-R_d(pb::ParameterBox) = pb.gas_constant / pb.molmass_dryair
+R_d(pb::ParameterBox) = pb.universal_gas_constant / pb.molmass_dryair
 
 name_map = Dict(
-    :gas_constant => :gas_constant,
+    :universal_gas_constant => :universal_gas_constant,
     :molar_mass_dry_air => :molmass_dryair,
     :param_2 => :new_parameter,
 )
@@ -38,9 +38,10 @@ name_map = Dict(
     # from default
     @test param_set.molmass_dryair ≈ 0.02897
     # overridden default
-    @test param_set.gas_constant ≈ 4.0
+    @test param_set.universal_gas_constant ≈ 4.0
     # derived in constructor
-    @test R_d(param_set) ≈ param_set.gas_constant / param_set.molmass_dryair
+    @test R_d(param_set) ≈
+          param_set.universal_gas_constant / param_set.molmass_dryair
     # from toml
     @test param_set.new_parameter ≈ 19.99
 

--- a/test/test_map.jl
+++ b/test/test_map.jl
@@ -59,7 +59,7 @@ import Thermodynamics.Parameters.ThermodynamicsParameters
 
 
     ThermodynamicsParameterMap = (;
-        :temperature_min_at_reference => :T_min_ref,
+        :temperature_min_reference => :T_min_ref,
         :entropy_water_vapor => :entropy_water_vapor,
         :entropy_dry_air => :entropy_dry_air,
         :entropy_reference_temperature => :entropy_reference_temperature,
@@ -80,8 +80,8 @@ import Thermodynamics.Parameters.ThermodynamicsParameters
         :latent_heat_vaporization_at_reference => :LH_v0,
         :temperature_saturation_adjustment_min => :T_min,
         # :temperature_saturation_adjustment_init_min => :T_init_min, # will need updated
-        :gas_constant => :gas_constant,
-        :temperature_mean_at_reference => :T_surf_ref,
+        :universal_gas_constant => :gas_constant,
+        :temperature_surface_reference => :T_surf_ref,
         :gravitational_acceleration => :grav,
         :temperature_homogenous_nucleation => :T_icenuc,
         :potential_temperature_reference_pressure => :p_ref_theta,

--- a/test/toml/parambox.toml
+++ b/test/toml/parambox.toml
@@ -1,4 +1,4 @@
-[gas_constant]
+[universal_gas_constant]
 type = "float"
 value = 4.0
 


### PR DESCRIPTION
## Purpose 
* Improves the documentation and consistency of ClimaParams
* Corrects some spelling mistakes in parameter names (requires downstream changes in Microphysics)
* Updates other parameter names for more consistency (closes #181)
* Update ocean specific heat capacity (closes #42)
* Adds gas constant and heat capacity for dry air as explicit parameters (closes #90)

## To-do
- [x] @trontrytel, @szy21, @kmdeck Please check the description updates in `parameters.toml` for accuracy
- [x] If you don't like the logo, replace it :)

Downstream fixes:
- Correct parameter names in `Microphysics.jl`: `rain_ventilation_coefficient_a`, `rain_ventilation_coefficient_b`, `snow_ventilation_coefficient_a', 'snow_ventilation_coefficient_b', `SB2006_cloud_gamma_distribution_coeff_nu`, `SB2006_rain_evaporation_coeff_alpha`, `SB2006_rain_evaporation_coeff_beta`, `liquid_water_specific_humidity_calibration_coefficient` 
- Correct parameter names in land: `soilCO2_pre_exponential_factor`, `SB2006_raindrops_equilibrium_mean_diameter,
- Use specific gas constant, `R_d = gas_constant_dry_air` and `R_v = gas_constant_vapor`, and `cp_d = isobaric_specific_heat_dry_air` as explicit ClimaParams in `Thermodynamics.jl` [Currently we calculate them locally from the universal gas constant and the molecular masses; however this precludes using them as fitting parameter to get a good real-gas fit of the ideal-gas law, which is what we want.]
- Correct parameter names in `Thermodynamics.jl`: `temperature_surface_reference`, `temperature_min_reference`, `universal_gas_constant` (instead of `gas_constant`) [though this shouldn't be needed much now]
- Change `mean_anomalistic_at_epoch` to `mean_anomaly_at_epoch` in `Insolation.jl`
- Use `gas_constant_dry_air` in RRTMG

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ x] I have read and checked the items on the review checklist.
