### PR TITLE
Convert "epoch_time" into DateTime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,12 @@ ClimaParams.jl Release Notes
 ========================
 main
 --------
+
+v0.12.1
+--------
+
 - Log parameter when getindex is called ([#243](https://github.com/CliMA/ClimaParams.jl/pull/243))
+- Change epoch_time to a DateTime ([#248](https://github.com/CliMA/ClimaParams.jl/pull/248))
 
 
 v0.12.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,14 @@ authors = ["Climate Modeling Alliance"]
 version = "0.12.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-julia = "1"
-Test = "1"
 TOML = "1"
-# Thermodynamics compat set for testing name maps
+Test = "1"
 Thermodynamics = "0.11.2"
-
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/ClimaParams.jl
+++ b/src/ClimaParams.jl
@@ -1,6 +1,7 @@
 module ClimaParams
 
 using TOML
+import Dates: DateTime
 
 export AbstractTOMLDict
 export ParamDict

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -119,7 +119,7 @@ correct Julia type based on the `valtype` string from the TOML file.
 - `pd::{AbstractTOMLDict}`: The parameter dictionary, used to get the float type.
 - `val`: The raw value of the parameter.
 - `valname::{AbstractString}`: The name of the parameter (for error messages).
-- `valtype::{AbstractString}`: The type string, e.g., "float", "integer", "string", "bool".
+- `valtype::{AbstractString}`: The type string, e.g., "float", "integer", "string", "bool", "datetime".
 
 # Returns
 - The value `val` converted to the appropriate type. Throws an error for an unknown `valtype`.
@@ -139,6 +139,8 @@ function _get_typed_value(
         return String(val)
     elseif valtype == "bool"
         return Bool(val)
+    elseif valtype == "datetime"
+        return DateTime(val)
     else
         error(
             "For parameter with identifier: \"",

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2333,9 +2333,9 @@ type = "float"
 description = "Total solar irradiance (TSI) at the mean orbital distance (W m⁻²)."
 
 [epoch_time]
-value = "2000-01-01T11:58:56.816"
-type = "string"
-description = "J2000 epoch (Jan 1, 2000 11:58:56.816 UTC) as string"
+value = 2000-01-01T11:58:56.816
+type = "datetime"
+description = "J2000 epoch (Jan 1, 2000 11:58:56.816 UTC) as a DateTime"
 
 [mean_anomaly_at_epoch]
 value = 6.24006014121


### PR DESCRIPTION


<!--- THESE LINES ARE COMMENTED -->
## Purpose 
PR #246 changed epoch_time from a float to a string. This causes a GPU error in ClimaAtmos:

```
insolation_params is of type Insolation.Parameters.InsolationParameters{Float32, String} which is not isbits.
```


## Content

Previously "epoch_time" was passed in as a string. This creates problem for gpu usage, because strings are not isbitstypes. This commit adds "datetime" as a valtype.
It is also changes "epoch_time" to a datetime in the toml file, which natively supports DateTimes. Users can still pass the "epoch_time" as a string. which is converted to a DateTime.



Alternatively, we can keep epoch_time as a string in ClimaParams, and then convert it into a DateTime in Insolation.jl.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
