### PR TITLE
Sea salt aerosol emission paramters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 ClimaParams.jl Release Notes
 ========================
+v1.1.6
+-------
+ - Add `ssa_size_bin_divisions` at MERRA-2 size bins to define bin edges and total number
+ - Add refrence factors `ssa_r_ref`, `ssa_u_ref`
+ - Add three modes (`ssa_gong_logfit_mode{1,2,3}`) of lognormal Gong approximation parameters in form (F, r, σg)
+ - Add bin flux scales for number and mass moments `ssa_gong_logfit_bin_0M_flux`, `ssa_gong_logfit_bin_3M_flux`
+ - Add parameterization constants `ssa_gong_wind_exponent`, `ssa_r80_per_dry`, `ssa_residence`
 
 v1.1.5
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "1.1.5"
+version = "1.1.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -3398,3 +3398,58 @@ description = "Steady Beres DC heating weight: Q_t(0)^2 = nogw_beres_steady_dc_f
 value = 1.0e6
 type = "float"
 description = "Largest convective-system scale (m) setting k_min = 2*pi/L in the even-folded horizontal constant H of the steady Beres source (steady/transient ratio depends on it only logarithmically). Source: Beres et al. (2004), DOI: 10.1175/1520-0469(2004)061<0324:AMOICG>2.0.CO;2."
+
+[ssa_residence]
+value = 47520.0
+type = "float"
+description = "Average residence time (sec) of sea salt aerosol mass in AeroCOM3 ensemble. Source: Gliss et al. (2021). DOI:10.5194/acp-21-87-2021"
+
+[ssa_size_bin_divisions]
+value = [0.03e-6, 0.1e-6, 0.5e-6, 1.5e-6, 5.0e-6, 10.0e-6]
+type = "float"
+description = "Double-sided sea salt aerosol dry-radius bin edges (m) from five-bin MERRA-2 scheme, ascending. i.e. bin1 (0.03e-6, 0.1e-6), bin2 (0.1e-6, 0.5e-6)"
+
+[ssa_r_ref]
+value = 1.0e-6
+type = "float"
+description = "Sea salt aerosol reference radius (m) to make Gong parameterization dimensionless."
+
+[ssa_u_ref]
+value = 1.0
+type = "float"
+description = "Wind reference speed (m/s) to make Gong parameterization dimensionless."
+
+[ssa_r80_per_dry]
+value = 2.0
+type = "float"
+description = "Dimensionless ratio of RH80% SSA to dry sea salt radius. Source: Lewis and Schwartz (2004)."
+
+[ssa_gong_wind_exponent]
+value = 3.41
+type = "float"
+description = "Dimensionless exponent on the 10m wind speed in the Gong source function (dimensionless). Source: Gong (2003). DOI: agupubs.onlinelibrary.wiley.com/doi/10.1029/2003GB002079"
+
+[ssa_gong_logfit_mode1]
+value = [0.2157, 0.05545, 17.02]
+type = "float"
+description = "Lognormal mode #1 parameters [flux scale (F) (m⁻² s⁻¹), dry mode radius (r) (μm), lognormal STD (σg) (-)] fit to Gong (2003) spectrum at u_10 = ssa_u_ref."
+
+[ssa_gong_logfit_mode2]
+value = [60.93, 0.0914, 1.813]
+type = "float"
+description = "Lognormal mode #2 parameters [flux scale (F) (m⁻² s⁻¹), dry mode radius (r) (μm), lognormal STD (σg) (-)] fit to Gong (2003) spectrum at u_10 = ssa_u_ref."
+
+[ssa_gong_logfit_mode3]
+value = [5.949, 0.776, 1.759]
+type = "float"
+description = "Lognormal mode #3 parameters [flux scale (F) (m⁻² s⁻¹), dry mode radius (r) (μm), lognormal STD (σg) (-)] fit to Gong (2003) spectrum at u_10 = ssa_u_ref."
+
+[ssa_gong_logfit_bin_0M_flux]
+value = [48.37, 41.92, 5.903, 1.122, 0.03885]
+type = "float"
+description = "Per-bin number flux scale (m⁻² s⁻¹) of the lognormal fit to Gong (2003) spectrum at u_10 = ssa_u_ref; Precomputed offine in ClimaAtmos.jl/docs/sea_salt_emission_fit.jl"
+
+[ssa_gong_logfit_bin_3M_flux]
+value = [1.589e-16, 3.575e-15, 4.557e-14, 1.238e-13, 1.32e-13]
+type = "float"
+description = "Per-bin dry-mass flux scale (kg m⁻² s⁻¹) of the lognormal fit to Gong (2003) spectrum at u_10 = ssa_u_ref; Precomputed offine in ClimaAtmos.jl/docs/sea_salt_emission_fit.jl"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Content

Reference values and coefficients for implementing Gong 2003 and Jaegle 2011 parameterizations for sea salt aerosol emission.

## Notes 
 -  `ssa_size_bin_divisions` is an array of values so that number of bins is derived from bin divisions rather than hard coded separately. IMO best for now but maybe change by aerosol module completion after we have firmer idea of final relationship between bins and optics.
 - `ssa_r_ref`, `ssa_u_ref`, `ssa_T_ref`, `ssa_gong_dim_factor` are SI dimensioned reference factors to non-dimensionalize parameterizations.
 - `ssa_gong_params_A`, `ssa_gong_params_B`, `ssa_gong_params_F`, `ssa_jaegle_params_J` are lists of coefficients rather than many individual entries. This syntax is used for some microphysics parameters in ClimaParams but not super common in the repo. 
 - `ssa_gong_wind_exponent` `ssa_gong_theta`, `ssa_r80_per_dry`, `ssa_residence` are normal parameters


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
