### PR TITLE
Tiny orbital parameter updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 ClimaParams.jl Release Notes
 ========================
 
+v1.1.3
+-------
+- Correct Earth's orbital parameters at the J2000 epoch and document their sources.
+  - `orbit_obliquity_at_epoch`: was 23.43278°, the obliquity at ~2050 rather than at J2000. Now 23.43927944° (84381.406″), the IAU 2006 value.
+  - `mean_anomaly_at_epoch`, `longitude_perihelion_at_epoch`, and `orbit_eccentricity_at_epoch` now use the JPL (Standish) 1800-2050 Earth-Moon barycenter elements as a single self-consistent set, replacing a mix of sources.
+  - `anomalistic_year_length`: was 31558464 s, described as 365.25 * `day` (which is 31557600 s). Now 31558433.5 s, derived from the same JPL rates.
+  - `astronomical_unit` and `length_orbit_semi_major`: 149597870000 m -> 149597870700 m, exact by the IAU 2012 definition.
+
 v1.1.2
 -------
 - Add `EDMF_interface_entr_efficiency` parameter.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2415,12 +2415,12 @@ type = "float"
 description = "Gravitational acceleration on the planet (m s⁻²)."
 
 [anomalistic_year_length]
-value = 31558464
+value = 31558433.5
 type = "float"
-description = "Length of an anomalistic year (s). Derived as 365.25 * `day`."
+description = "Length of an anomalistic year (s). Derived as 365.2596 * `day`, from the JPL (Standish) 1800-2050 Earth-Moon barycenter rates: 360 / (35999.37244981 - 0.32327364) °/century."
 
 [length_orbit_semi_major]
-value = 149597870000
+value = 149597870700
 type = "float"
 description = "Semi-major axis of the planetary orbit (m). Derived as 1 * `astronomical_unit`."
 
@@ -2435,24 +2435,24 @@ type = "datetime"
 description = "J2000 epoch (Jan 1, 2000 11:58:55.816 UTC) as a DateTime"
 
 [mean_anomaly_at_epoch]
-value = 6.24006014121
+value = 6.24002139020
 type = "float"
-description = "Mean anomaly at J2000 epoch (radians). Corresponds to 357.52911°."
+description = "Mean anomaly at J2000 epoch (radians). Corresponds to 357.52688973°, from the JPL (Standish) 1800-2050 Earth-Moon barycenter elements as mean longitude minus longitude of perihelion, 100.46457166° - 102.93768193°."
 
 [orbit_obliquity_at_epoch]
-value = 0.40909278483
+value = 0.40909260060
 type = "float"
-description = "Obliquity of the ecliptic at J2000 epoch (radians). Corresponds to 23.43929°."
+description = "Mean obliquity of the ecliptic at J2000 epoch (radians). Corresponds to 23.43927944° = 84381.406\", the IAU 2006 value (Capitaine et al. 2003)."
 
 [longitude_perihelion_at_epoch]
-value = 4.93835675864
+value = 4.93819412764
 type = "float"
-description = "Longitude of perihelion at J2000 epoch (radians). Corresponds to 282.947°."
+description = "Longitude of perihelion of the Sun's apparent orbit at J2000 epoch, measured eastward from the vernal equinox (radians). Corresponds to 282.93768193°, i.e. the JPL (Standish) 1800-2050 Earth-Moon barycenter longitude of perihelion 102.93768193° plus 180°."
 
 [orbit_eccentricity_at_epoch]
-value = 0.016708634
+value = 0.01671123
 type = "float"
-description = "Orbital eccentricity at J2000 epoch (unitless)."
+description = "Orbital eccentricity at J2000 epoch (unitless). JPL (Standish) 1800-2050 Earth-Moon barycenter value."
 
 # Universal Physical Constants
 
@@ -2502,9 +2502,9 @@ type = "float"
 description = "Stefan-Boltzmann constant ($\\sigma$) (W m⁻² K⁻⁴)."
 
 [astronomical_unit]
-value = 149597870000
+value = 149597870700
 type = "float"
-description = "Astronomical unit (AU) (m)."
+description = "Astronomical unit (AU) (m). Exact by the IAU 2012 definition (Resolution B2)."
 
 [avogadro_constant]
 value = 6.02214076e+23

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2437,22 +2437,22 @@ description = "J2000 epoch (Jan 1, 2000 11:58:55.816 UTC) as a DateTime"
 [mean_anomaly_at_epoch]
 value = 6.24006014121
 type = "float"
-description = "Mean anomaly at epoch (radians). Corresponds to 357.52911°."
+description = "Mean anomaly at J2000 epoch (radians). Corresponds to 357.52911°."
 
 [orbit_obliquity_at_epoch]
-value = 0.408979125113246
+value = 0.40909278483
 type = "float"
-description = "Obliquity of the ecliptic at epoch (radians). Corresponds to 23.43278°."
+description = "Obliquity of the ecliptic at J2000 epoch (radians). Corresponds to 23.43929°."
 
 [longitude_perihelion_at_epoch]
-value = 4.938188299449
+value = 4.93835675864
 type = "float"
-description = "Longitude of perihelion at epoch (radians). Corresponds to 282.9373°."
+description = "Longitude of perihelion at J2000 epoch (radians). Corresponds to 282.947°."
 
 [orbit_eccentricity_at_epoch]
 value = 0.016708634
 type = "float"
-description = "Orbital eccentricity at epoch (unitless)."
+description = "Orbital eccentricity at J2000 epoch (unitless)."
 
 # Universal Physical Constants
 


### PR DESCRIPTION
- Tiny changes to orbital parameters, to make them self-consistent and aligned with IAU standards.
- Bump patch release

Note: This may affect some ClimaAtmos reproducibility tests with 'TimeVaryingInsolation` (specifically, aquaplanet_nonequil_allsky_gw_res_2M and aquaplanet_equil_allsky_gw_raw, 1e-5 relative changes in insolation). I prefer to keep this a patch release, but atmos may need a ref_counter bump.