### PR TITLE
Add reference-state parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 ClimaParams.jl Release Notes
 ========================
 
+v1.1.5
+-------
+- Add reference-state shape parameters: `reference_temperature_exponent` (7), `reference_relative_humidity` (0.5), `reference_moisture_cutoff_pressure` (25000 Pa).
+
 v1.1.4
 -------
 - Add parameters for vertical velocity dependent rain formation.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "1.1.4"
+version = "1.1.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2486,6 +2486,21 @@ value = 220
 type = "float"
 description = "Minimum temperature in a reference temperature profile (K)."
 
+[reference_temperature_exponent]
+value = 7
+type = "float"
+description = "Exponent s_ref of the Exner function in the hydrostatic reference temperature profile T_r(p) = T_min + (T_sfc - T_min) Π(p)^s_ref [-]."
+
+[reference_relative_humidity]
+value = 0.5
+type = "float"
+description = "Reference relative humidity used to build a reference total moisture specific humidity profile [-]."
+
+[reference_moisture_cutoff_pressure]
+value = 25000
+type = "float"
+description = "Pressure cutoff above which the reference-state total-water specific humidity is clipped to zero [Pa]. Keeps the reference profile confined to the troposphere, avoiding unphysical stratospheric growth."
+
 [universal_gas_constant]
 value = 8.3144598
 type = "float"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add reference-state shape parameters: `reference_temperature_exponent` (7), `reference_relative_humidity` (0.5), `reference_moisture_cutoff_pressure` (25000 Pa).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
